### PR TITLE
CallFrame now a struct

### DIFF
--- a/runtime/ishtar.vm/FFI/ForeignFunctionInterface.cs
+++ b/runtime/ishtar.vm/FFI/ForeignFunctionInterface.cs
@@ -52,13 +52,13 @@ public unsafe class ForeignFunctionInterface
     }
 
     [Conditional("STATIC_VALIDATE_IL")]
-    public static void StaticValidate(void* p, CallFrame frame)
+    public static void StaticValidate(void* p, CallFrame* frame)
     {
         if (p != null) return;
-        frame.vm.FastFail(WNE.STATE_CORRUPT, "Null pointer state.", frame);
+        frame->vm.FastFail(WNE.STATE_CORRUPT, "Null pointer state.", frame);
     }
     [Conditional("STATIC_VALIDATE_IL")]
-    public static void StaticValidateField(CallFrame current, IshtarObject** arg1, string name)
+    public static void StaticValidateField(CallFrame* current, IshtarObject** arg1, string name)
     {
         StaticValidate(*arg1, current);
         var @class = ( *arg1)->clazz;
@@ -67,19 +67,19 @@ public unsafe class ForeignFunctionInterface
     }
 
     [Conditional("STATIC_VALIDATE_IL")]
-    public static void StaticValidate(CallFrame frame, stackval* value, RuntimeIshtarClass* clazz)
+    public static void StaticValidate(CallFrame* frame, stackval* value, RuntimeIshtarClass* clazz)
     {
-        frame.assert(clazz is not null);
-        frame.assert(value->type != VeinTypeCode.TYPE_NONE);
+        frame->assert(clazz is not null);
+        frame->assert(value->type != VeinTypeCode.TYPE_NONE);
         var obj = IshtarMarshal.Boxing(frame, value);
-        frame.assert(obj->__gc_id != -1);
+        frame->assert(obj->__gc_id != -1);
         var currentClass = obj->clazz;
         var targetClass = clazz;
-        frame.assert(currentClass->ID == targetClass->ID, $"{currentClass->Name}.ID == {targetClass->Name}.ID");
+        frame->assert(currentClass->ID == targetClass->ID, $"{currentClass->Name}.ID == {targetClass->Name}.ID");
     }
 
     [Conditional("STATIC_VALIDATE_IL")]
-    public static void StaticValidate(CallFrame current, IshtarObject** arg1)
+    public static void StaticValidate(CallFrame* current, IshtarObject** arg1)
     {
         StaticValidate(*arg1, current);
         var @class = (*arg1)->clazz;
@@ -87,7 +87,7 @@ public unsafe class ForeignFunctionInterface
         VirtualMachine.Assert(!@class->IsAbstract, WNE.TYPE_LOAD, $"Class '{@class->FullName->NameWithNS}' abstract.", current);
     }
     [Conditional("STATIC_VALIDATE_IL")]
-    public static void StaticTypeOf(CallFrame current, IshtarObject** arg1, VeinTypeCode code)
+    public static void StaticTypeOf(CallFrame* current, IshtarObject** arg1, VeinTypeCode code)
     {
         StaticValidate(*arg1, current);
         var @class = (*arg1)->clazz;

--- a/runtime/ishtar.vm/IAssemblyResolver.cs
+++ b/runtime/ishtar.vm/IAssemblyResolver.cs
@@ -113,6 +113,6 @@ namespace vein.runtime
         protected override void debug(string s) { }
 
 
-        public CallFrame sys_frame => Vault.vm.Frames.ModuleLoaderFrame;
+        public CallFrame* sys_frame => Vault.vm.Frames.ModuleLoaderFrame;
     }
 }

--- a/runtime/ishtar.vm/IWatchDog.cs
+++ b/runtime/ishtar.vm/IWatchDog.cs
@@ -1,8 +1,8 @@
 namespace ishtar
 {
-    public interface IWatchDog
+    public unsafe interface IWatchDog
     {
-        void FastFail(WNE type, string msg, CallFrame frame = null);
+        void FastFail(WNE type, string msg, CallFrame* frame = null);
         void ValidateLastError();
     }
 }

--- a/runtime/ishtar.vm/NativeExports.cs
+++ b/runtime/ishtar.vm/NativeExports.cs
@@ -10,32 +10,34 @@ public static unsafe class NativeExports
 
     public static stackval* VM_EXECUTE_METHOD(VirtualMachine vm, Types.FrameRef* frame)
     {
-        var vault = vm.Vault;
-        var type = vault.GlobalFindType(*frame->runtime_token);
+        throw null;
+        //var vault = vm.Vault;
+        //var type = vault.GlobalFindType(*frame->runtime_token);
 
-        if (type is null)
-            return null;
+        //if (type is null)
+        //    return null;
 
-        if (type->Methods->Length >= frame->index)
-            return null;
+        //if (type->Methods->Length >= frame->index)
+        //    return null;
 
-        var method = type->Methods->Get(frame->index);
+        //var method = type->Methods->Get(frame->index);
 
-        if (*method is not { } or { IsExtern: true } or { IsStatic: false })
-            return null;
+        //if (*method is not { } or { IsExtern: true } or { IsStatic: false })
+        //    return null;
 
-        
 
-        var callframe = new CallFrame(vm)
-        {
-            args = frame->args,
-            level = 0,
-            method = method
-        };
+        //var callframe = CallFrame.Create(method, null)
 
-        vm.exec_method(callframe);
+        //var callframe = new CallFrame()
+        //{
+        //    args = frame->args,
+        //    level = 0,
+        //    method = method
+        //};
 
-        return callframe.returnValue.Ref;
+        //vm.exec_method(callframe);
+
+        //return callframe.returnValue.Ref;
     }
 
     public static class Types

--- a/runtime/ishtar.vm/Program.cs
+++ b/runtime/ishtar.vm/Program.cs
@@ -63,28 +63,26 @@ unsafe
 
     var args_ = stackalloc stackval[1];
 
-    var frame = new CallFrame(vm)
-    {
-        args = args_,
-        method = entry_point,
-        level = 0
-    };
+
+
+    var frame = CallFrame.Create(entry_point, null);
+    frame->args = args_;
 
 
     var watcher = Stopwatch.StartNew();
     vm.exec_method(frame);
 
-    if (frame.exception is not null)
+    if (!frame->exception.IsDefault())
     {
         Console.ForegroundColor = ConsoleColor.Red;
-        Console.WriteLine($"unhandled exception '{frame.exception.value->clazz->Name}' was thrown. \n" +
-                          $"{frame.exception.stack_trace}");
+        Console.WriteLine($"unhandled exception '{frame->exception.value->clazz->Name}' was thrown. \n" +
+                          $"{frame->exception.GetStackTrace()}");
         Console.ForegroundColor = ConsoleColor.White;
     }
 
     watcher.Stop();
     Console.WriteLine($"Elapsed: {watcher.Elapsed}");
-
+    frame->Dispose();
     vm.Dispose();
 
     return 0;

--- a/runtime/ishtar.vm/SmartPointer.cs
+++ b/runtime/ishtar.vm/SmartPointer.cs
@@ -1,14 +1,9 @@
 namespace ishtar;
 
-public readonly unsafe struct SmartPointer<T>(ushort size, CallFrame frame,
-    delegate*<CallFrame, int, T*> allocator,
-    delegate*<CallFrame, T*, int, void> free) : IDisposable where T : unmanaged
+public readonly unsafe struct SmartPointer<T>(ushort size, CallFrame* frame,
+    delegate*<CallFrame*, int, T*> allocator,
+    delegate*<CallFrame*, T*, int, void> free) : IDisposable where T : unmanaged
 {
-#if DEBUG
-    private readonly nint[] OriginalAddress = new nint[1];
-
-    internal void CaptureAddress() => OriginalAddress[0] = (nint)Ref;
-#endif
     public readonly T* Ref = allocator(frame, size);
     public readonly ushort size = size;
     

--- a/runtime/ishtar.vm/Trace.cs
+++ b/runtime/ishtar.vm/Trace.cs
@@ -1,15 +1,9 @@
 namespace ishtar;
 
-internal class IshtarTrace
+internal struct IshtarTrace()
 {
-    private static bool useConsole;
-    private static bool useFile;
-
-    public IshtarTrace()
-    {
-        useConsole = Environment.GetCommandLineArgs().Contains("--sys::log::use-console=1");
-        useFile = Environment.GetCommandLineArgs().Contains("--sys::log::use-file=1"); // TODO
-    }
+    private bool useConsole = Environment.GetCommandLineArgs().Contains("--sys::log::use-console=1");
+    private bool useFile = Environment.GetCommandLineArgs().Contains("--sys::log::use-file=1");
 
     public void println(string s)
     {

--- a/runtime/ishtar.vm/__builtin/B_App.cs
+++ b/runtime/ishtar.vm/__builtin/B_App.cs
@@ -8,9 +8,9 @@ namespace ishtar
     {
         [IshtarExport(0, "@_get_os_value")]
         [IshtarExportFlags(Public | Static)]
-        public static IshtarObject* GetOSValue(CallFrame current, IshtarObject** args)
+        public static IshtarObject* GetOSValue(CallFrame* current, IshtarObject** args)
         {
-            var gc = current.GetGC();
+            var gc = current->GetGC();
             // TODO remove using RuntimeInformation
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 return gc.ToIshtarObject(0, current);
@@ -24,7 +24,7 @@ namespace ishtar
 
         [IshtarExport(1, "@_exit")]
         [IshtarExportFlags(Public | Static)]
-        public static IshtarObject* Exit(CallFrame current, IshtarObject** args)
+        public static IshtarObject* Exit(CallFrame* current, IshtarObject** args)
         {
             var exitCode = args[0];
 
@@ -32,14 +32,14 @@ namespace ishtar
             ForeignFunctionInterface.StaticTypeOf(current, &exitCode, TYPE_I4);
             ForeignFunctionInterface.StaticValidateField(current, &exitCode, "!!value");
 
-            current.vm.halt(IshtarMarshal.ToDotnetInt32(exitCode, current));
+            current->vm.halt(IshtarMarshal.ToDotnetInt32(exitCode, current));
 
             return null;
         }
 
         [IshtarExport(2, "@_switch_flag")]
         [IshtarExportFlags(Public | Static)]
-        public static IshtarObject* SwitchFlag(CallFrame current, IshtarObject** args)
+        public static IshtarObject* SwitchFlag(CallFrame* current, IshtarObject** args)
         {
             var key = args[0];
             var value = args[1];
@@ -55,7 +55,7 @@ namespace ishtar
             var clr_key = IshtarMarshal.ToDotnetString(key, current);
             var clr_value = IshtarMarshal.ToDotnetBoolean(value, current);
 
-            current.vm.Config.Set(clr_key, clr_value);
+            current->vm.Config.Set(clr_key, clr_value);
 
             return null;
         }
@@ -63,13 +63,13 @@ namespace ishtar
         public static void InitTable(ForeignFunctionInterface ffi)
         {
             ffi.Add("@_get_os_value", Public | Static | Extern)->
-                AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&GetOSValue);
+                AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&GetOSValue);
 
             ffi.Add("@_exit", Public | Static | Extern, ("msg", TYPE_STRING), ("code", TYPE_I4))->
-                AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&Exit);
+                AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&Exit);
 
             ffi.Add("@_switch_flag", Public | Static | Extern, ("key", TYPE_STRING), ("value", TYPE_BOOLEAN))
-                ->AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&SwitchFlag);
+                ->AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&SwitchFlag);
         }
     }
 }

--- a/runtime/ishtar.vm/__builtin/B_Field.cs
+++ b/runtime/ishtar.vm/__builtin/B_Field.cs
@@ -6,25 +6,25 @@ public static unsafe class B_Field
 {
     [IshtarExport(3, "i_call_Field_setValue")]
     [IshtarExportFlags(Public | Static)]
-    public static IshtarObject* FieldSetValue(CallFrame current, IshtarObject** args)
+    public static IshtarObject* FieldSetValue(CallFrame* current, IshtarObject** args)
     {
         var arg1 = args[0];
         var arg2 = args[1];
         var arg3 = args[2];
 
-        current.ThrowException(KnowTypes.PlatformIsNotSupportFault(current), "i_call_Field_setValue currently is not support.");
+        current->ThrowException(KnowTypes.PlatformIsNotSupportFault(current), "i_call_Field_setValue currently is not support.");
 
         return null;
     }
 
     [IshtarExport(3, "i_call_Field_getValue")]
     [IshtarExportFlags(Public | Static)]
-    public static IshtarObject* FieldGetValue(CallFrame current, IshtarObject** args)
+    public static IshtarObject* FieldGetValue(CallFrame* current, IshtarObject** args)
     {
         var arg1 = args[0];
         var arg2 = args[1];
 
-        current.ThrowException(KnowTypes.PlatformIsNotSupportFault(current), "i_call_Field_getValue currently is not support.");
+        current->ThrowException(KnowTypes.PlatformIsNotSupportFault(current), "i_call_Field_getValue currently is not support.");
 
         return null;
     }

--- a/runtime/ishtar.vm/__builtin/B_File.cs
+++ b/runtime/ishtar.vm/__builtin/B_File.cs
@@ -7,23 +7,24 @@ public static unsafe class B_File
 {
     [IshtarExport(1, "i_call_fs_File_info")]
     [IshtarExportFlags(Public | Static)]
-    public static IshtarObject* GetFileInfo(CallFrame current, IshtarObject** args)
+    public static IshtarObject* GetFileInfo(CallFrame* current, IshtarObject** args)
     {
-        var raw = args[0];
+        throw null;
+        //var raw = args[0];
 
 
-        ForeignFunctionInterface.StaticValidate(current, &raw);
-        ForeignFunctionInterface.StaticTypeOf(current, &raw, TYPE_STRING);
+        //ForeignFunctionInterface.StaticValidate(current, &raw);
+        //ForeignFunctionInterface.StaticTypeOf(current, &raw, TYPE_STRING);
 
-        ForeignFunctionInterface.StaticValidateField(current, &raw, "!!value");
+        //ForeignFunctionInterface.StaticValidateField(current, &raw, "!!value");
 
-        var path = IshtarMarshal.ToDotnetString(raw, current);
-
-
-        var fi = new FileInfo(path);
+        //var path = IshtarMarshal.ToDotnetString(raw, current);
 
 
-        return Marshals.GetFor<FileInfo>(current).Marshal(fi, current);
+        //var fi = new FileInfo(path);
+
+
+        //return Marshals.GetFor<FileInfo>(current).Marshal(fi, current);
     }
 
 

--- a/runtime/ishtar.vm/__builtin/B_Function.cs
+++ b/runtime/ishtar.vm/__builtin/B_Function.cs
@@ -6,18 +6,18 @@ public static unsafe class B_Function
 {
     [IshtarExport(2, "i_call_Function_call")]
     [IshtarExportFlags(Public | Static)]
-    public static IshtarObject* Call(CallFrame current, IshtarObject** args)
+    public static IshtarObject* Call(CallFrame* current, IshtarObject** args)
     {
-        current.ThrowException(KnowTypes.PlatformIsNotSupportFault(current), "i_call_Field_setValue currently is not support.");
+       // current.ThrowException(KnowTypes.PlatformIsNotSupportFault(current), "i_call_Field_setValue currently is not support.");
 
         return null;
     }
 
     [IshtarExport(4, "i_call_Function_create")]
     [IshtarExportFlags(Public | Static)]
-    public static IshtarObject* Create(CallFrame current, IshtarObject** args)
+    public static IshtarObject* Create(CallFrame* current, IshtarObject** args)
     {
-        current.ThrowException(KnowTypes.PlatformIsNotSupportFault(current), "i_call_Field_setValue currently is not support.");
+        //current.ThrowException(KnowTypes.PlatformIsNotSupportFault(current), "i_call_Field_setValue currently is not support.");
 
         return null;
     }

--- a/runtime/ishtar.vm/__builtin/B_GC.cs
+++ b/runtime/ishtar.vm/__builtin/B_GC.cs
@@ -6,20 +6,20 @@ public static unsafe class B_GC
 {
     [IshtarExport(0, "i_call_GC_get_allocated")]
     [IshtarExportFlags(Public | Static)]
-    public static IshtarObject* GetAllocatedBytes(CallFrame current, IshtarObject** _)
-        => current.GetGC().ToIshtarObject(current.vm.GC.Stats.total_allocations, current);
+    public static IshtarObject* GetAllocatedBytes(CallFrame* current, IshtarObject** _)
+        => current->GetGC().ToIshtarObject(current->vm.GC.Stats.total_allocations, current);
 
     [IshtarExport(0, "i_call_GC_get_alive_objects")]
     [IshtarExportFlags(Public | Static)]
-    public static IshtarObject* GetAliveObjects(CallFrame current, IshtarObject** _)
-        => current.GetGC().ToIshtarObjectT(current.vm.GC.Stats.alive_objects, current);
+    public static IshtarObject* GetAliveObjects(CallFrame* current, IshtarObject** _)
+        => current->GetGC().ToIshtarObjectT(current->vm.GC.Stats.alive_objects, current);
 
     public static void InitTable(ForeignFunctionInterface ffi)
     {
         ffi.Add("i_call_GC_get_allocated", Public | Static | Extern)->
-            AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&GetAllocatedBytes);
+            AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&GetAllocatedBytes);
 
         ffi.Add("i_call_GC_get_alive_objects", Public | Static | Extern)->
-            AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&GetAliveObjects);
+            AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&GetAliveObjects);
     }
 }

--- a/runtime/ishtar.vm/__builtin/B_IEEEConsts.cs
+++ b/runtime/ishtar.vm/__builtin/B_IEEEConsts.cs
@@ -6,49 +6,49 @@ namespace ishtar
     {
         [IshtarExport(0, "getHalfNaN")]
         [IshtarExportFlags(Public | Static)]
-        public static IshtarObject* getHalfNaN(CallFrame current, IshtarObject** args)
+        public static IshtarObject* getHalfNaN(CallFrame* current, IshtarObject** args)
         {
-            current.vm.FastFail(WNE.MISSING_METHOD, "[B_IEEEConsts::getHalfNaN]", current);
+            current->vm.FastFail(WNE.MISSING_METHOD, "[B_IEEEConsts::getHalfNaN]", current);
             return null;
         }
 
         public static void InitTable(ForeignFunctionInterface ffi)
         {
             ffi.Add("i_call_get_Half_NaN", Public | Static | Extern)
-                ->AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&getHalfNaN);
+                ->AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&getHalfNaN);
 
             ffi.Add("i_call_get_Float_NaN", Public | Static | Extern)
-                ->AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&getHalfNaN);
+                ->AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&getHalfNaN);
 
             ffi.Add("i_call_get_Decimal_NaN", Public | Static | Extern)
-                    ->AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&getHalfNaN);
+                    ->AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&getHalfNaN);
 
             ffi.Add("i_call_get_Double_NaN", Public | Static | Extern)
-                ->AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&getHalfNaN);
+                ->AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&getHalfNaN);
 
             ffi.Add("i_call_get_Half_Infinity", Public | Static | Extern)
-                    ->AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&getHalfNaN);
+                    ->AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&getHalfNaN);
 
             ffi.Add("i_call_get_Float_Infinity", Public | Static | Extern)
-                ->AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&getHalfNaN);
+                ->AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&getHalfNaN);
 
             ffi.Add("i_call_get_Decimal_Infinity", Public | Static | Extern)
-                ->AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&getHalfNaN);
+                ->AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&getHalfNaN);
 
             ffi.Add("i_call_get_Double_Infinity", Public | Static | Extern)
-                ->AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&getHalfNaN);
+                ->AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&getHalfNaN);
 
             ffi.Add("i_call_get_Half_NegativeInfinity", Public | Static | Extern)
-                ->AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&getHalfNaN);
+                ->AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&getHalfNaN);
 
             ffi.Add("i_call_get_Float_NegativeInfinity", Public | Static | Extern)
-                ->AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&getHalfNaN);
+                ->AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&getHalfNaN);
 
             ffi.Add("i_call_get_Decimal_NegativeInfinity", Public | Static | Extern)
-                ->AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&getHalfNaN);
+                ->AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&getHalfNaN);
 
             ffi.Add("i_call_get_Double_NegativeInfinity", Public | Static | Extern)
-                ->AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&getHalfNaN);
+                ->AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&getHalfNaN);
 
         }
     }

--- a/runtime/ishtar.vm/__builtin/B_Out.cs
+++ b/runtime/ishtar.vm/__builtin/B_Out.cs
@@ -9,13 +9,13 @@ namespace ishtar
     {
         [IshtarExport(1, "@_println")]
         [IshtarExportFlags(Public | Static)]
-        public static IshtarObject* FPrintLn(CallFrame current, IshtarObject** args)
+        public static IshtarObject* FPrintLn(CallFrame* current, IshtarObject** args)
         {
             var arg1 = args[0];
 
             if (arg1 == null)
             {
-                current.ThrowException(KnowTypes.NullPointerException(current));
+                current->ThrowException(KnowTypes.NullPointerException(current));
                 return null;
             }
 
@@ -34,17 +34,17 @@ namespace ishtar
 
         [IshtarExport(0, "@_readline")]
         [IshtarExportFlags(Public | Static)]
-        public static IshtarObject* FReadLine(CallFrame current, IshtarObject** args)
-            => current.GetGC().ToIshtarObject(In.ReadLine(), current);
+        public static IshtarObject* FReadLine(CallFrame* current, IshtarObject** args)
+            => current->GetGC().ToIshtarObject(In.ReadLine(), current);
 
 
         public static void InitTable(ForeignFunctionInterface ffi)
         {
             ffi.Add("@_println", Public | Static | Extern, ("val", TYPE_STRING))
-                ->AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&FPrintLn);
+                ->AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&FPrintLn);
 
             ffi.Add("@_readline", Public | Static | Extern, TYPE_STRING.AsRuntimeClass(ffi.vm.Types))
-                ->AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&FReadLine);
+                ->AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&FReadLine);
         }
     }
 }

--- a/runtime/ishtar.vm/__builtin/B_String.cs
+++ b/runtime/ishtar.vm/__builtin/B_String.cs
@@ -10,40 +10,40 @@ namespace ishtar
         {
             ffi.Add("i_call_String_Concat", Private | Static | Extern,
                     ("v1", TYPE_STRING), ("v2", TYPE_STRING))
-                ->AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&Concat)
+                ->AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&Concat)
                 ;
 
             ffi.Add("i_call_String_Equal", Private | Static | Extern,
                     ("v1", TYPE_STRING), ("v2", TYPE_STRING))
-                ->AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&StrEqual)
+                ->AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&StrEqual)
                 ;
 
             ffi.Add("i_call_String_Trim_Start", Private | Static | Extern,
                     ("v1", TYPE_STRING))
-                ->AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&TrimStart)
+                ->AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&TrimStart)
                 ;
 
             ffi.Add("i_call_String_Trim_End", Private | Static | Extern,
                     ("v1", TYPE_STRING))
-                ->AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&TrimEnd)
+                ->AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&TrimEnd)
                 ;
 
             ffi.Add("i_call_String_fmt", Private | Static | Extern,
                     ("template", TYPE_STRING), ("array", TYPE_ARRAY))
-                ->AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&Fmt)
+                ->AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&Fmt)
                 ;
 
             ffi.Add("i_call_String_Contains", Private | Static | Extern,
                     ("v1", TYPE_STRING), ("v2", TYPE_STRING))
-                ->AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&Contains)
+                ->AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&Contains)
                 ;
         }
 
         [IshtarExportFlags(Private | Static)]
         [IshtarExport(2, "i_call_String_fmt")]
-        public static IshtarObject* Fmt(CallFrame frame, IshtarObject** args)
+        public static IshtarObject* Fmt(CallFrame* frame, IshtarObject** args)
         {
-            var gc = frame.GetGC();
+            var gc = frame->GetGC();
             var template_obj = args[0];
             var array_obj = args[1];
 
@@ -73,9 +73,9 @@ namespace ishtar
 
         [IshtarExportFlags(Private | Static)]
         [IshtarExport(2, "i_call_String_Concat")]
-        public static IshtarObject* Concat(CallFrame frame, IshtarObject** args)
+        public static IshtarObject* Concat(CallFrame* frame, IshtarObject** args)
         {
-            var gc = frame.GetGC();
+            var gc = frame->GetGC();
             var i_str1 = args[0];
             var i_str2 = args[1];
 
@@ -96,9 +96,9 @@ namespace ishtar
 
         [IshtarExportFlags(Private | Static)]
         [IshtarExport(2, "i_call_String_Contains")]
-        public static IshtarObject* Contains(CallFrame frame, IshtarObject** args)
+        public static IshtarObject* Contains(CallFrame* frame, IshtarObject** args)
         {
-            var gc = frame.GetGC();
+            var gc = frame->GetGC();
             var i_str1 = args[0];
             var i_str2 = args[1];
 
@@ -118,9 +118,9 @@ namespace ishtar
 
         [IshtarExportFlags(Private | Static)]
         [IshtarExport(2, "i_call_String_Equal")]
-        public static IshtarObject* StrEqual(CallFrame frame, IshtarObject** args)
+        public static IshtarObject* StrEqual(CallFrame* frame, IshtarObject** args)
         {
-            var gc = frame.GetGC();
+            var gc = frame->GetGC();
             var i_str1 = args[0];
             var i_str2 = args[1];
 
@@ -137,9 +137,9 @@ namespace ishtar
             return gc.ToIshtarObject(result, frame);
         }
 
-        public static IshtarObject* TemplateFunctionApply(CallFrame frame, IshtarObject** args, Func<string, string> apply)
+        public static IshtarObject* TemplateFunctionApply(CallFrame* frame, IshtarObject** args, Func<string, string> apply)
         {
-            var gc = frame.GetGC();
+            var gc = frame->GetGC();
             var str1 = args[0];
             ForeignFunctionInterface.StaticValidate(frame, &str1);
             ForeignFunctionInterface.StaticTypeOf(frame, &str1, TYPE_STRING);
@@ -154,10 +154,10 @@ namespace ishtar
 
         [IshtarExportFlags(Private | Static)]
         [IshtarExport(1, "i_call_String_trim_start")]
-        public static IshtarObject* TrimStart(CallFrame frame, IshtarObject** args)
+        public static IshtarObject* TrimStart(CallFrame* frame, IshtarObject** args)
             => TemplateFunctionApply(frame, args, x => x.TrimStart());
         [IshtarExport(1, "i_call_String_trim_end")]
-        public static IshtarObject* TrimEnd(CallFrame frame, IshtarObject** args)
+        public static IshtarObject* TrimEnd(CallFrame* frame, IshtarObject** args)
             => TemplateFunctionApply(frame, args, x => x.TrimEnd());
     }
 }

--- a/runtime/ishtar.vm/__builtin/B_Sys.cs
+++ b/runtime/ishtar.vm/__builtin/B_Sys.cs
@@ -7,7 +7,7 @@ public static unsafe class B_Sys
 {
     [IshtarExport(1, "@value2string")]
     [IshtarExportFlags(Public | Static)]
-    public static IshtarObject* ValueToString(CallFrame current, IshtarObject** args)
+    public static IshtarObject* ValueToString(CallFrame* current, IshtarObject** args)
     {
         var arg1 = args[0];
 
@@ -19,7 +19,7 @@ public static unsafe class B_Sys
 
     [IshtarExport(1, "@object2string")]
     [IshtarExportFlags(Public | Static)]
-    public static IshtarObject* ObjectToString(CallFrame current, IshtarObject** args)
+    public static IshtarObject* ObjectToString(CallFrame* current, IshtarObject** args)
     {
         var arg1 = args[0];
 
@@ -31,20 +31,20 @@ public static unsafe class B_Sys
 
     [IshtarExport(0, "@queryPerformanceCounter")]
     [IshtarExportFlags(Public | Static)]
-    public static IshtarObject* QueryPerformanceCounter(CallFrame current, IshtarObject** _)
-        => current.GetGC().ToIshtarObject(Stopwatch.GetTimestamp(), current);
+    public static IshtarObject* QueryPerformanceCounter(CallFrame* current, IshtarObject** _)
+        => current->GetGC().ToIshtarObject(Stopwatch.GetTimestamp(), current);
 
     public static void InitTable(ForeignFunctionInterface ffi)
     {
         //ffi.Add(ffi.vm.CreateInternalMethod("@value2string", Public | Static | Extern,
         //        new VeinArgumentRef("value", ffi.vm.Types->ValueTypeClass))
-        //    ->AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&ValueToString));
+        //    ->AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&ValueToString));
         //ffi.vm.CreateInternalMethod("@object2string", Public | Static | Extern,
         //        new VeinArgumentRef("value", ffi.vm.Types.ObjectClass))
-        //    .AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&ObjectToString)
+        //    .AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&ObjectToString)
         //    .AddInto(table, x => x.Name);
         //ffi.vm.CreateInternalMethod("@queryPerformanceCounter", Public | Static | Extern)
-        //    .AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&QueryPerformanceCounter)
+        //    .AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&QueryPerformanceCounter)
         //    .AddInto(table, x => x.Name);
     }
 }

--- a/runtime/ishtar.vm/__builtin/B_Type.cs
+++ b/runtime/ishtar.vm/__builtin/B_Type.cs
@@ -6,11 +6,11 @@ public static unsafe class B_Type
 {
     [IshtarExport(1, "i_call_Type_findByName")]
     [IshtarExportFlags(Public | Static)]
-    public static IshtarObject* FindByName(CallFrame current, IshtarObject** args)
+    public static IshtarObject* FindByName(CallFrame* current, IshtarObject** args)
     {
         var arg1 = args[0];
-        var vault = current.vm.Vault;
-        var gc = current.GetGC();
+        var vault = current->vm.Vault;
+        var gc = current->GetGC();
 
         ForeignFunctionInterface.StaticValidate(current, &arg1);
         ForeignFunctionInterface.StaticTypeOf(current, &arg1, VeinTypeCode.TYPE_STRING);
@@ -20,14 +20,14 @@ public static unsafe class B_Type
         var results = vault.GlobalFindType(name);
         if (results.Length == 0)
         {
-            current.ThrowException(KnowTypes.TypeNotFoundFault(current), $"'{name}' not found.");
+            current->ThrowException(KnowTypes.TypeNotFoundFault(current), $"'{name}' not found.");
             return null;
         }
 
         if (results.Length > 1)
         {
             // todo, add info about all types
-            current.ThrowException(KnowTypes.MultipleTypeFoundFault(current), $"Multiple detected '{name}' types.");
+            current->ThrowException(KnowTypes.MultipleTypeFoundFault(current), $"Multiple detected '{name}' types.");
             return null;
         }
 
@@ -38,7 +38,7 @@ public static unsafe class B_Type
 
     [IshtarExport(1, "i_call_Type_findField")]
     [IshtarExportFlags(Public | Static)]
-    public static IshtarObject* FindField(CallFrame current, IshtarObject** args)
+    public static IshtarObject* FindField(CallFrame* current, IshtarObject** args)
     {
         var arg1 = args[0];
         var arg2 = args[1];
@@ -47,7 +47,7 @@ public static unsafe class B_Type
         ForeignFunctionInterface.StaticValidate(current, &arg2);
         ForeignFunctionInterface.StaticTypeOf(current, &arg2, VeinTypeCode.TYPE_STRING);
 
-        current.ThrowException(KnowTypes.PlatformIsNotSupportFault(current));
+        current->ThrowException(KnowTypes.PlatformIsNotSupportFault(current));
 
         return null;
     }
@@ -59,13 +59,13 @@ public static unsafe class B_Type
     {
         //ffi.Add(ffi.vm.CreateInternalMethod("i_call_Type_findByName", Public | Static | Extern,
         //        ("name", VeinTypeCode.TYPE_STRING))
-        //    ->AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&FindByName));
+        //    ->AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&FindByName));
         //ffi.Add(ffi.vm.CreateInternalMethod("i_call_Type_findField", Public | Static | Extern,
         //        new VeinArgumentRef("type", ThisClass), ("name", VeinTypeCode.TYPE_STRING))
-        //    .AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&FindField));
+        //    .AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&FindField));
         //ffi.vm.CreateInternalMethod("i_call_Type_findMethod", Public | Static | Extern,
         //        new VeinArgumentRef("type", ThisClass), new VeinArgumentRef("name", ffi.vm.Types.StringClass))
-        //    .AsNative((delegate*<CallFrame, IshtarObject**, IshtarObject*>)&FindField)
+        //    .AsNative((delegate*<CallFrame*, IshtarObject**, IshtarObject*>)&FindField)
         //    .AddInto(table, x => x.Name);
     }
 }

--- a/runtime/ishtar.vm/__builtin/mappings/sys/Marshals.cs
+++ b/runtime/ishtar.vm/__builtin/mappings/sys/Marshals.cs
@@ -5,14 +5,14 @@ public static unsafe class Marshals
 {
     private static Dictionary<Type, ITransitAllocator> _list = new();
 
-    public static TransitAllocator<T> GetFor<T>(CallFrame frame) where T : class
+    public static TransitAllocator<T> GetFor<T>(CallFrame* frame) where T : class
     {
         var key = typeof(T);
 
         if (_list.ContainsKey(key))
             return _list[typeof(T)] as TransitAllocator<T>;
 
-        frame.ThrowException(KnowTypes.TypeNotFoundFault(frame), "failed fetch transit allocator");
+        frame->ThrowException(KnowTypes.TypeNotFoundFault(frame), "failed fetch transit allocator");
 
         return null;
     }

--- a/runtime/ishtar.vm/__builtin/mappings/sys/TransitAllocator.cs
+++ b/runtime/ishtar.vm/__builtin/mappings/sys/TransitAllocator.cs
@@ -2,12 +2,12 @@ namespace ishtar;
 
 using vein.runtime;
 
-public unsafe abstract class TransitAllocator<T> : ITransitAllocator where T : class
+public abstract unsafe class TransitAllocator<T> : ITransitAllocator where T : class
 {
     public abstract IshtarObject* Marshal(T t, CallFrame frame);
 
     public abstract VeinClass Type { get; }
 
-    public RuntimeIshtarClass* RuntimeType(CallFrame frame)
+    public RuntimeIshtarClass* RuntimeType(CallFrame* frame)
         => KnowTypes.FromCache(Type.FullName, frame);
 }

--- a/runtime/ishtar.vm/collections/NativeList.cs
+++ b/runtime/ishtar.vm/collections/NativeList.cs
@@ -277,3 +277,4 @@ public unsafe struct NativeList<T> : IDisposable where T : unmanaged, IEq<T>
 
 public unsafe delegate void UnsafeForEach_Delegate<T>(T* item) where T : unmanaged;
 public unsafe delegate bool UnsafeFilter_Delegate<T>(T* item) where T : unmanaged;
+public unsafe delegate void UnsafeVoid_Delegate<T>(T* item) where T : unmanaged;

--- a/runtime/ishtar.vm/ishtar.vm.csproj
+++ b/runtime/ishtar.vm/ishtar.vm.csproj
@@ -63,6 +63,7 @@
   <ItemGroup>
     <ProjectReference Include="..\common\vein.common.csproj" />
     <ProjectReference Include="..\ishtar.base\ishtar.base.csproj" />
+    <ProjectReference Include="..\ishtar.vm.libuv\ishtar.vm.libuv.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Update="includes\gc.lib">

--- a/runtime/ishtar.vm/runtime/IshtarArray.cs
+++ b/runtime/ishtar.vm/runtime/IshtarArray.cs
@@ -43,30 +43,30 @@ namespace ishtar
 
         public Block _block;
 
-        public IshtarObject* this[uint index, CallFrame frame]
+        public IshtarObject* this[uint index, CallFrame* frame]
         {
             get => Get(index, frame);
             set => Set(index, value, frame);
         }
 
-        public IshtarObject* Get(uint index, CallFrame frame)
+        public IshtarObject* Get(uint index, CallFrame* frame)
         {
             if (!ElementClass->IsPrimitive) return elements[index];
-            var result = frame.vm.GC.AllocObject(ElementClass, frame);
+            var result = frame->vm.GC.AllocObject(ElementClass, frame);
             var el = elements[index];
             var offset = result->clazz->Field["!!value"]->vtable_offset;
             result->vtable[offset] = el->vtable[offset];
             return result;
         }
 
-        public void Set(uint index, IshtarObject* value, CallFrame frame)
+        public void Set(uint index, IshtarObject* value, CallFrame* frame)
         {
             ForeignFunctionInterface.StaticValidate(frame, &value);
             var value_class = value->clazz;
             VirtualMachine.Assert(value_class->TypeCode == ElementClass->TypeCode || value_class->IsInner(ElementClass), WNE.TYPE_MISMATCH, "Element type mismatch.", frame);
             if (index >= length)
             {
-                frame.vm.FastFail(WNE.OUT_OF_RANGE, $"", frame);
+                frame->vm.FastFail(WNE.OUT_OF_RANGE, $"", frame);
                 return;
             }
 

--- a/runtime/ishtar.vm/runtime/IshtarFrames.cs
+++ b/runtime/ishtar.vm/runtime/IshtarFrames.cs
@@ -3,57 +3,21 @@ namespace ishtar;
 
 using vein.runtime;
 
-public unsafe class IshtarFrames(VirtualMachine vm)
+public unsafe struct IshtarFrames
 {
-    public CallFrame ModuleLoaderFrame = new(vm)
+    public IshtarFrames(VirtualMachine vm)
     {
-        method = vm.DefineEmptySystemMethod("#module")
-    };
-
-    public CallFrame VTableFrame(RuntimeIshtarClass* clazz)
-    {
-        var method = clazz->FindMethod($"#type()");
-
-        if (method is not null)
-            return new CallFrame(vm) { method = method };
-
-        return new CallFrame(vm)
-        {
-            method = clazz->DefineMethod($"#type()", clazz, MethodFlags.Special)
-        };
-    }
-
-    public CallFrame StaticCtor(RuntimeIshtarClass* clazz)
-    {
-        var method = clazz->FindMethod($"#static_ctor()");
-
-        if (method is not null)
-            return new CallFrame(vm) { method = method };
-
-        return new CallFrame(vm)
-        {
-            method = clazz->DefineMethod("#static_ctor()", null, MethodFlags.Special | MethodFlags.Static)
-        };
+        EntryPoint = CallFrame.Create(vm.DefineEmptySystemMethod("ishtar_entry"), null);
+        ModuleLoaderFrame = CallFrame.Create(vm.DefineEmptySystemMethod("#module"), EntryPoint);
+        Jit = CallFrame.Create(vm.DefineEmptySystemMethod("#jit"), EntryPoint);
+        GarbageCollector = CallFrame.Create(vm.DefineEmptySystemMethod("#gc"), EntryPoint);
+        NativeLoader = CallFrame.Create(vm.DefineEmptySystemMethod("#ffi"), EntryPoint);
     }
 
 
-    public CallFrame EntryPoint = new(vm)
-    {
-        method = vm.DefineEmptySystemMethod("ishtar_entry")
-    };
-
-    public CallFrame Jit = new(vm)
-    {
-        method = vm.DefineEmptySystemMethod("#jit")
-    };
-
-    public CallFrame GarbageCollector = new(vm)
-    {
-        method = vm.DefineEmptySystemMethod("#gc")
-    };
-
-    public CallFrame NativeLoader = new(vm)
-    {
-        method = vm.DefineEmptySystemMethod("#ffi")
-    };
+    public readonly CallFrame* ModuleLoaderFrame;
+    public readonly CallFrame* EntryPoint;
+    public readonly CallFrame* Jit;
+    public readonly CallFrame* GarbageCollector;
+    public readonly CallFrame* NativeLoader;
 }

--- a/runtime/ishtar.vm/runtime/IshtarMarshal.cs
+++ b/runtime/ishtar.vm/runtime/IshtarMarshal.cs
@@ -7,14 +7,14 @@ namespace ishtar
     using static vein.runtime.VeinTypeCode;
     public static unsafe class IshtarMarshal
     {
-        public static IshtarObject* ToIshtarObject(this IshtarGC gc, string str, CallFrame frame)
+        public static IshtarObject* ToIshtarObject(this IshtarGC gc, string str, CallFrame* frame)
         {
             var arg = gc.AllocObject(TYPE_STRING.AsRuntimeClass(gc.VM.Types), frame);
             var clazz = arg->clazz;
             arg->vtable[clazz->Field["!!value"]->vtable_offset] = StringStorage.Intern(str);
             return arg;
         }
-        public static IshtarObject* ToIshtarObject(this IshtarGC gc, int dotnet_value, CallFrame frame)
+        public static IshtarObject* ToIshtarObject(this IshtarGC gc, int dotnet_value, CallFrame* frame)
         {
             var obj = gc.AllocObject(TYPE_I4.AsRuntimeClass(gc.VM.Types), frame);
             var clazz = obj->clazz;
@@ -23,7 +23,7 @@ namespace ishtar
             return obj;
         }
 
-        public static IshtarObject* ToIshtarObject(this IshtarGC gc, bool dotnet_value, CallFrame frame)
+        public static IshtarObject* ToIshtarObject(this IshtarGC gc, bool dotnet_value, CallFrame* frame)
         {
             var obj = gc.AllocObject(TYPE_BOOLEAN.AsRuntimeClass(gc.VM.Types), frame);
             var clazz = obj->clazz;
@@ -31,7 +31,7 @@ namespace ishtar
 
             return obj;
         }
-        public static IshtarObject* ToIshtarObject(this IshtarGC gc, short dotnet_value, CallFrame frame)
+        public static IshtarObject* ToIshtarObject(this IshtarGC gc, short dotnet_value, CallFrame* frame)
         {
             var obj = gc.AllocObject(TYPE_I2.AsRuntimeClass(gc.VM.Types), frame);
             var clazz = obj->clazz;
@@ -39,7 +39,7 @@ namespace ishtar
 
             return obj;
         }
-        public static IshtarObject* ToIshtarObject(this IshtarGC gc, byte dotnet_value, CallFrame frame)
+        public static IshtarObject* ToIshtarObject(this IshtarGC gc, byte dotnet_value, CallFrame* frame)
         {
             var obj = gc.AllocObject(TYPE_I1.AsRuntimeClass(gc.VM.Types), frame);
             var clazz = obj->clazz;
@@ -47,7 +47,7 @@ namespace ishtar
 
             return obj;
         }
-        public static IshtarObject* ToIshtarObject(this IshtarGC gc, long dotnet_value, CallFrame frame)
+        public static IshtarObject* ToIshtarObject(this IshtarGC gc, long dotnet_value, CallFrame* frame)
         {
             var obj = gc.AllocObject(TYPE_I8.AsRuntimeClass(gc.VM.Types), frame);
             var clazz = obj->clazz;
@@ -56,7 +56,7 @@ namespace ishtar
             return obj;
         }
 
-        public static IshtarObject* ToIshtarObject(this IshtarGC gc, float dotnet_value, CallFrame frame)
+        public static IshtarObject* ToIshtarObject(this IshtarGC gc, float dotnet_value, CallFrame* frame)
         {
             var obj = gc.AllocObject(TYPE_I8.AsRuntimeClass(gc.VM.Types), frame);
             var clazz = obj->clazz;
@@ -65,14 +65,14 @@ namespace ishtar
             return obj;
         }
 
-        public static IshtarObject* ToIshtarObject(this IshtarGC gc, nint dotnet_value, CallFrame frame)
+        public static IshtarObject* ToIshtarObject(this IshtarGC gc, nint dotnet_value, CallFrame* frame)
         {
             var obj = gc.AllocObject(TYPE_RAW.AsRuntimeClass(gc.VM.Types), frame);
             obj->vtable = (void**)dotnet_value;
             return obj;
         }
 
-        public static IshtarObject* ToIshtarObject(this IshtarGC gc, ushort dotnet_value, CallFrame frame)
+        public static IshtarObject* ToIshtarObject(this IshtarGC gc, ushort dotnet_value, CallFrame* frame)
         {
             var obj = gc.AllocObject(TYPE_U2.AsRuntimeClass(gc.VM.Types), frame);
             var clazz = obj->clazz;
@@ -82,7 +82,7 @@ namespace ishtar
         }
 
 
-        public static IshtarObject* ToIshtarObjectT<X>(this IshtarGC gc, X value, CallFrame frame)
+        public static IshtarObject* ToIshtarObjectT<X>(this IshtarGC gc, X value, CallFrame* frame)
         {
             switch (typeof(X))
             {
@@ -119,7 +119,7 @@ namespace ishtar
             }
         }
 
-        public static IshtarObject* ToIshtarObject_Raw(this IshtarGC gc, object value, CallFrame frame)
+        public static IshtarObject* ToIshtarObject_Raw(this IshtarGC gc, object value, CallFrame* frame)
         {
             switch (value.GetType())
             {
@@ -158,7 +158,7 @@ namespace ishtar
 
         private static X cast<X>(object o) => (X)o;
 
-        public static X ToDotnet<X>(IshtarObject* obj, CallFrame frame)
+        public static X ToDotnet<X>(IshtarObject* obj, CallFrame* frame)
         {
             switch (typeof(X))
             {
@@ -187,82 +187,82 @@ namespace ishtar
                 case { } when typeof(X) == typeof(string):
                     return (X)(object)ToDotnetString(obj, frame);
                 default:
-                    frame.vm.FastFail(WNE.TYPE_MISMATCH,
+                    frame->vm.FastFail(WNE.TYPE_MISMATCH,
                         $"[marshal::ToDotnet] converter for '{typeof(X).Name}' not support.", frame);
                     return default;
             }
         }
 
-        public static sbyte ToDotnetInt8(IshtarObject* obj, CallFrame frame)
+        public static sbyte ToDotnetInt8(IshtarObject* obj, CallFrame* frame)
         {
             ForeignFunctionInterface.StaticTypeOf(frame, &obj, TYPE_I1);
             var clazz = obj->clazz;
             return (sbyte)(sbyte*)obj->vtable[clazz->Field["!!value"]->vtable_offset];
         }
-        public static short ToDotnetInt16(IshtarObject* obj, CallFrame frame)
+        public static short ToDotnetInt16(IshtarObject* obj, CallFrame* frame)
         {
             ForeignFunctionInterface.StaticTypeOf(frame, &obj, TYPE_I2);
             var clazz = obj->clazz;
             return (short)(short*)obj->vtable[clazz->Field["!!value"]->vtable_offset];
         }
-        public static int ToDotnetInt32(IshtarObject* obj, CallFrame frame)
+        public static int ToDotnetInt32(IshtarObject* obj, CallFrame* frame)
         {
             ForeignFunctionInterface.StaticTypeOf(frame, &obj, TYPE_I4);
             var clazz = obj->clazz;
             return (int)(int*)obj->vtable[clazz->Field["!!value"]->vtable_offset];
         }
-        public static long ToDotnetInt64(IshtarObject* obj, CallFrame frame)
+        public static long ToDotnetInt64(IshtarObject* obj, CallFrame* frame)
         {
             ForeignFunctionInterface.StaticTypeOf(frame, &obj, TYPE_I8);
             var clazz = obj->clazz;
             return (long)(long*)obj->vtable[clazz->Field["!!value"]->vtable_offset];
         }
 
-        public static byte ToDotnetUInt8(IshtarObject* obj, CallFrame frame)
+        public static byte ToDotnetUInt8(IshtarObject* obj, CallFrame* frame)
         {
             ForeignFunctionInterface.StaticTypeOf(frame, &obj, TYPE_U1);
             var clazz = obj->clazz;
             return (byte)(byte*)obj->vtable[clazz->Field["!!value"]->vtable_offset];
         }
-        public static ushort ToDotnetUInt16(IshtarObject* obj, CallFrame frame)
+        public static ushort ToDotnetUInt16(IshtarObject* obj, CallFrame* frame)
         {
             ForeignFunctionInterface.StaticTypeOf(frame, &obj, TYPE_U2);
             var clazz = obj->clazz;
             return (ushort)(ushort*)obj->vtable[clazz->Field["!!value"]->vtable_offset];
         }
-        public static uint ToDotnetUInt32(IshtarObject* obj, CallFrame frame)
+        public static uint ToDotnetUInt32(IshtarObject* obj, CallFrame* frame)
         {
             ForeignFunctionInterface.StaticTypeOf(frame, &obj, TYPE_U4);
             var clazz = obj->clazz;
             return (uint)(uint*)obj->vtable[clazz->Field["!!value"]->vtable_offset];
         }
-        public static ulong ToDotnetUInt64(IshtarObject* obj, CallFrame frame)
+        public static ulong ToDotnetUInt64(IshtarObject* obj, CallFrame* frame)
         {
             ForeignFunctionInterface.StaticTypeOf(frame, &obj, TYPE_U8);
             var clazz = obj->clazz;
             return (ulong)(ulong*)obj->vtable[clazz->Field["!!value"]->vtable_offset];
         }
-        public static bool ToDotnetBoolean(IshtarObject* obj, CallFrame frame)
+        public static bool ToDotnetBoolean(IshtarObject* obj, CallFrame* frame)
         {
             ForeignFunctionInterface.StaticTypeOf(frame, &obj, TYPE_BOOLEAN);
             var clazz = obj->clazz;
             return (int)(int*)obj->vtable[clazz->Field["!!value"]->vtable_offset] == 1;
         }
-        public static char ToDotnetChar(IshtarObject* obj, CallFrame frame)
+        public static char ToDotnetChar(IshtarObject* obj, CallFrame* frame)
         {
             ForeignFunctionInterface.StaticTypeOf(frame, &obj, TYPE_CHAR);
             var clazz = obj->clazz;
             return (char)(int)(int*)obj->vtable[clazz->Field["!!value"]->vtable_offset];
         }
 
-        public static float ToDotnetFloat(IshtarObject* obj, CallFrame frame)
+        public static float ToDotnetFloat(IshtarObject* obj, CallFrame* frame)
         {
             ForeignFunctionInterface.StaticTypeOf(frame, &obj, TYPE_R4);
             var clazz = obj->clazz;
             return BitConverter.Int32BitsToSingle((int)(int*)obj->vtable[clazz->Field["!!value"]->vtable_offset]);
         }
 
-        public static string ToDotnetString(IshtarObject* obj, CallFrame frame)
+        public static string ToDotnetString(IshtarObject* obj, CallFrame* frame)
         {
             ForeignFunctionInterface.StaticTypeOf(frame, &obj, TYPE_STRING);
             var clazz = obj->clazz;
@@ -270,39 +270,39 @@ namespace ishtar
             return StringStorage.GetString(p, frame);
         }
 
-        public static nint ToDotnetPointer(IshtarObject* obj, CallFrame frame)
+        public static nint ToDotnetPointer(IshtarObject* obj, CallFrame* frame)
         {
             ForeignFunctionInterface.StaticTypeOf(frame, &obj, TYPE_RAW);
             return (nint)obj->vtable;
         }
 
-        public static IshtarObject* ToIshtarString(IshtarObject* obj, CallFrame frame) => obj->clazz->TypeCode switch
+        public static IshtarObject* ToIshtarString(IshtarObject* obj, CallFrame* frame) => obj->clazz->TypeCode switch
         {
-            TYPE_U1 => frame.GetGC().ToIshtarObject($"{ToDotnetUInt8(obj, frame)}", frame),
-            TYPE_I1 => frame.GetGC().ToIshtarObject($"{ToDotnetInt8(obj, frame)}", frame),
-            TYPE_U2 => frame.GetGC().ToIshtarObject($"{ToDotnetUInt16(obj, frame)}", frame),
-            TYPE_I2 => frame.GetGC().ToIshtarObject($"{ToDotnetInt16(obj, frame)}", frame),
-            TYPE_U4 => frame.GetGC().ToIshtarObject($"{ToDotnetUInt32(obj, frame)}", frame),
-            TYPE_I4 => frame.GetGC().ToIshtarObject($"{ToDotnetInt32(obj, frame)}", frame),
-            TYPE_U8 => frame.GetGC().ToIshtarObject($"{ToDotnetUInt64(obj, frame)}", frame),
-            TYPE_I8 => frame.GetGC().ToIshtarObject($"{ToDotnetInt64(obj, frame)}", frame),
-            TYPE_R4 => frame.GetGC().ToIshtarObject($"{ToDotnetFloat(obj, frame)}", frame),
-            TYPE_BOOLEAN => frame.GetGC().ToIshtarObject($"{ToDotnetBoolean(obj, frame)}", frame),
-            TYPE_CHAR => frame.GetGC().ToIshtarObject($"{ToDotnetChar(obj, frame)}", frame),
-            TYPE_RAW => frame.GetGC().ToIshtarObject($"0x{ToDotnetPointer(obj, frame):X8}", frame),
+            TYPE_U1 => frame->GetGC().ToIshtarObject($"{ToDotnetUInt8(obj, frame)}", frame),
+            TYPE_I1 => frame->GetGC().ToIshtarObject($"{ToDotnetInt8(obj, frame)}", frame),
+            TYPE_U2 => frame->GetGC().ToIshtarObject($"{ToDotnetUInt16(obj, frame)}", frame),
+            TYPE_I2 => frame->GetGC().ToIshtarObject($"{ToDotnetInt16(obj, frame)}", frame),
+            TYPE_U4 => frame->GetGC().ToIshtarObject($"{ToDotnetUInt32(obj, frame)}", frame),
+            TYPE_I4 => frame->GetGC().ToIshtarObject($"{ToDotnetInt32(obj, frame)}", frame),
+            TYPE_U8 => frame->GetGC().ToIshtarObject($"{ToDotnetUInt64(obj, frame)}", frame),
+            TYPE_I8 => frame->GetGC().ToIshtarObject($"{ToDotnetInt64(obj, frame)}", frame),
+            TYPE_R4 => frame->GetGC().ToIshtarObject($"{ToDotnetFloat(obj, frame)}", frame),
+            TYPE_BOOLEAN => frame->GetGC().ToIshtarObject($"{ToDotnetBoolean(obj, frame)}", frame),
+            TYPE_CHAR => frame->GetGC().ToIshtarObject($"{ToDotnetChar(obj, frame)}", frame),
+            TYPE_RAW => frame->GetGC().ToIshtarObject($"0x{ToDotnetPointer(obj, frame):X8}", frame),
             TYPE_STRING => obj,
-            //TYPE_FUNCTION => frame.GetGC().ToIshtarObject(new IshtarLayerFunction(obj, frame).Name, frame),
+            //TYPE_FUNCTION => frame->GetGC().ToIshtarObject(new IshtarLayerFunction(obj, frame).Name, frame),
             _ => ReturnDefault(nameof(ToIshtarString), $"Convert to '{obj->clazz->TypeCode}' not supported.", frame),
         };
 
-        private static IshtarObject* ReturnDefault(string name, string msg, CallFrame frame)
+        private static IshtarObject* ReturnDefault(string name, string msg, CallFrame* frame)
         {
-            frame.vm.FastFail(WNE.TYPE_MISMATCH,
+            frame->vm.FastFail(WNE.TYPE_MISMATCH,
                 $"[marshal::{name}] {msg}", frame);
             return default;
         }
 
-        public static stackval UnBoxing(CallFrame frame, IshtarObject* obj)
+        public static stackval UnBoxing(CallFrame* frame, IshtarObject* obj)
         {
             if (obj == null)
                 return new stackval();
@@ -317,7 +317,7 @@ namespace ishtar
 
             if (@class->TypeCode is TYPE_NONE or > TYPE_ARRAY or < TYPE_NONE)
             {
-                frame.vm.FastFail(WNE.ACCESS_VIOLATION,
+                frame->vm.FastFail(WNE.ACCESS_VIOLATION,
                     $"Scalar value type cannot be extracted. [{@class->FullName->NameWithNS}]\n" +
                     "Invalid memory address is possible.\n" +
                     "Please report the problem into https://github.com/vein-lang/vein/issues",
@@ -361,7 +361,7 @@ namespace ishtar
                     val.data.f_r4 = ToDotnetFloat(obj, frame);
                     break;
                 case TYPE_R8 or TYPE_R2 or TYPE_R16:
-                    frame.vm.FastFail(WNE.ACCESS_VIOLATION,
+                    frame->vm.FastFail(WNE.ACCESS_VIOLATION,
                         "Unboxing operation error.\n" +
                         $"Scalar value type '{val.type}' cannot be extracted.\n" +
                         "Currently is not support.\n" +
@@ -374,7 +374,7 @@ namespace ishtar
         }
 
 
-        public static stackval LegacyBoxing(CallFrame frame, VeinTypeCode type_code, string value)
+        public static stackval LegacyBoxing(CallFrame* frame, VeinTypeCode type_code, string value)
         {
             if (string.IsNullOrEmpty(value))
                 return new stackval { type = type_code };
@@ -382,7 +382,7 @@ namespace ishtar
             var val = new stackval { type = type_code };
             if (type_code is TYPE_OBJECT or TYPE_CLASS or TYPE_ARRAY or TYPE_RAW or TYPE_FUNCTION or TYPE_NONE or TYPE_TOKEN or TYPE_VOID or TYPE_CHAR)
             {
-                frame.vm.FastFail(WNE.ACCESS_VIOLATION,
+                frame->vm.FastFail(WNE.ACCESS_VIOLATION,
                     $"[LegacyBoxing] Scalar value type cannot be extracted. [{type_code}]\n" +
                     "Invalid memory address is possible.\n" +
                     "Please report the problem into https://github.com/vein-lang/vein/issues",
@@ -426,7 +426,7 @@ namespace ishtar
                 val.data.p = (nint)StringStorage.Intern(value);
                 break;
                 case TYPE_R8 or TYPE_R2 or TYPE_R16:
-                frame.vm.FastFail(WNE.ACCESS_VIOLATION,
+                frame->vm.FastFail(WNE.ACCESS_VIOLATION,
                     "Unboxing operation error.\n" +
                     $"Scalar value type '{val.type}' cannot be extracted.\n" +
                     "Currently is not support.\n" +
@@ -442,11 +442,11 @@ namespace ishtar
 
 
 
-        public static IshtarObject* Boxing(CallFrame frame, stackval* p)
+        public static IshtarObject* Boxing(CallFrame* frame, stackval* p)
         {
             if (p->type == TYPE_NONE)
             {
-                frame.vm.FastFail(WNE.ACCESS_VIOLATION,
+                frame->vm.FastFail(WNE.ACCESS_VIOLATION,
                     "Boxing operation error.\n" +
                     $"p->type is NONE [{p->type}]\n" +
                     "Invalid allocation or incorrect type setup possible.\n" +
@@ -459,7 +459,7 @@ namespace ishtar
                 return (IshtarObject*)p->data.p;
             if (p->type is TYPE_NONE or > TYPE_ARRAY or < TYPE_NONE)
             {
-                frame.vm.FastFail(WNE.ACCESS_VIOLATION,
+                frame->vm.FastFail(WNE.ACCESS_VIOLATION,
                     "Boxing operation error.\n" +
                     $"Scalar value type cannot be extracted. [{p->type}]\n" +
                     "Invalid memory address is possible.\n" +
@@ -468,7 +468,7 @@ namespace ishtar
                 return null;
             }
 
-            var gc = frame.GetGC();
+            var gc = frame->GetGC();
             var clazz = p->type.AsRuntimeClass(gc.VM.Types);
             var obj = gc.AllocObject(clazz, frame);
 
@@ -476,7 +476,7 @@ namespace ishtar
 
             if (obj->vtable is null)
             {
-                frame.vm.FastFail(WNE.ACCESS_VIOLATION,
+                frame->vm.FastFail(WNE.ACCESS_VIOLATION,
                     "Boxing operation error.\n" +
                     $"vtable is null [{p->type}]\n" +
                     "Invalid allocation or incorrect type setup possible.\n" +

--- a/runtime/ishtar.vm/runtime/IshtarObject.cs
+++ b/runtime/ishtar.vm/runtime/IshtarObject.cs
@@ -38,10 +38,10 @@ namespace ishtar
             return true;
         }
 
-        public static IshtarObject* IsInstanceOf(CallFrame frame, IshtarObject* @this, RuntimeIshtarClass* @class)
+        public static IshtarObject* IsInstanceOf(CallFrame* frame, IshtarObject* @this, RuntimeIshtarClass* @class)
         {
             if (!@class->is_inited)
-                @class->init_vtable(frame.vm);
+                @class->init_vtable(frame->vm);
             if (@this == null)
                 return null;
             if (@class->IsInterface)
@@ -49,21 +49,21 @@ namespace ishtar
             return IsAssignableFrom(frame, @class, @this->clazz) ? @this : null;
         }
 
-        public static IshtarObject* IsInstanceOfByRef(CallFrame frame, IshtarObject* c, RuntimeIshtarClass* @class)
+        public static IshtarObject* IsInstanceOfByRef(CallFrame* frame, IshtarObject* c, RuntimeIshtarClass* @class)
         {
             // temporary cast to\from interface is not support
-            frame.ThrowException(KnowTypes.IncorrectCastFault(frame));
+            frame->ThrowException(KnowTypes.IncorrectCastFault(frame));
             return c;
         }
 
-        public static bool IsAssignableFrom(CallFrame frame, RuntimeIshtarClass* c1, RuntimeIshtarClass* c2)
+        public static bool IsAssignableFrom(CallFrame* frame, RuntimeIshtarClass* c1, RuntimeIshtarClass* c2)
         {
-            if (!c1->is_inited) c1->init_vtable(frame.vm);
-            if (!c2->is_inited) c2->init_vtable(frame.vm);
+            if (!c1->is_inited) c1->init_vtable(frame->vm);
+            if (!c2->is_inited) c2->init_vtable(frame->vm);
             // TODO: Array detection
             // TODO: Generic detection
             // TODO: Interfrace detection
-            if (c1->FullName == frame.vm.Types->ObjectClass->FullName)
+            if (c1->FullName == frame->vm.Types->ObjectClass->FullName)
                 return true;
             return c1->IsInner(c2);
         }

--- a/runtime/ishtar.vm/runtime/KnowTypes.cs
+++ b/runtime/ishtar.vm/runtime/KnowTypes.cs
@@ -14,69 +14,63 @@ public static unsafe partial class KnowTypes
         public static class Native
         {
             public static QualityTypeName NativeHandleTypeName =
-                new QualityTypeName("std", nameof(NativeHandle), "global::vein/lang/native");
+                new("std", nameof(NativeHandle), "global::vein/lang/native");
 
-            public static RuntimeIshtarClass* NativeHandle(CallFrame frame)
+            public static RuntimeIshtarClass* NativeHandle(CallFrame* frame)
                 => findType(NativeHandleTypeName, frame);
         }
 
 
         public static QualityTypeName FileNotFoundFaultTypeName =
-            new QualityTypeName("std", nameof(FileNotFoundFault), "global::vein/lang");
+            new("std", nameof(FileNotFoundFault), "global::vein/lang");
 
-        public static RuntimeIshtarClass* FileNotFoundFault(CallFrame frame)
+        public static RuntimeIshtarClass* FileNotFoundFault(CallFrame* frame)
             => findType(FileNotFoundFaultTypeName, frame);
     }
 
 
-    public static QualityTypeName TypeInfoTypeName =
-        new QualityTypeName("std", nameof(Type), "global::vein/lang");
-    public static QualityTypeName FieldInfoTypeName =
-        new QualityTypeName("std", nameof(Field), "global::vein/lang");
-    public static QualityTypeName FunctionInfoTypeName =
-        new QualityTypeName("std", nameof(Function), "global::vein/lang");
+    public static QualityTypeName TypeInfoTypeName = new("std", nameof(Type), "global::vein/lang");
+    public static QualityTypeName FieldInfoTypeName = new("std", nameof(Field), "global::vein/lang");
+    public static QualityTypeName FunctionInfoTypeName = new("std", nameof(Function), "global::vein/lang");
 
-    public static QualityTypeName NullPointerExceptionTypeName =
-        new QualityTypeName("std", "NullPointerException", "global::vein/lang");
-    public static QualityTypeName IncorrectCastFaultTypeName =
-        new QualityTypeName("std", "IncorrectCastFault", "global::vein/lang");
+    public static QualityTypeName NullPointerExceptionTypeName = new("std", "NullPointerException", "global::vein/lang");
+    public static QualityTypeName IncorrectCastFaultTypeName = new("std", "IncorrectCastFault", "global::vein/lang");
     public static QualityTypeName FreeImmortalObjectFaultTypeName =
-        new QualityTypeName("std", nameof(FreeImmortalObjectFault), "global::vein/lang");
+        new("std", nameof(FreeImmortalObjectFault), "global::vein/lang");
     public static QualityTypeName TypeNotFoundFaultTypeName =
-        new QualityTypeName("std", nameof(TypeNotFoundFault), "global::vein/lang/reflection");
+        new("std", nameof(TypeNotFoundFault), "global::vein/lang/reflection");
     public static QualityTypeName MultipleTypeFoundFaultTypeName =
-        new QualityTypeName("std", nameof(MultipleTypeFoundFault), "global::vein/lang/reflection");
+        new("std", nameof(MultipleTypeFoundFault), "global::vein/lang/reflection");
     public static QualityTypeName PlatformIsNotSupportFaultTypeName =
-        new QualityTypeName("std", nameof(PlatformIsNotSupportFault), "global::vein/lang");
-    public static QualityTypeName IshatFault =
-        new QualityTypeName("std", nameof(IshatFault), "global::vein/lang");
+        new("std", nameof(PlatformIsNotSupportFault), "global::vein/lang");
+    public static QualityTypeName IshatFault = new("std", nameof(IshatFault), "global::vein/lang");
 
-    public static RuntimeIshtarClass* NullPointerException(CallFrame frame)
+    public static RuntimeIshtarClass* NullPointerException(CallFrame* frame)
         => findType(NullPointerExceptionTypeName, frame);
 
-    public static RuntimeIshtarClass* IncorrectCastFault(CallFrame frame)
+    public static RuntimeIshtarClass* IncorrectCastFault(CallFrame* frame)
         => findType(IncorrectCastFaultTypeName, frame);
 
-    public static RuntimeIshtarClass* FreeImmortalObjectFault(CallFrame frame)
+    public static RuntimeIshtarClass* FreeImmortalObjectFault(CallFrame* frame)
         => findType(FreeImmortalObjectFaultTypeName, frame);
 
-    public static RuntimeIshtarClass* TypeNotFoundFault(CallFrame frame)
+    public static RuntimeIshtarClass* TypeNotFoundFault(CallFrame* frame)
         => findType(TypeNotFoundFaultTypeName, frame);
 
-    public static RuntimeIshtarClass* MultipleTypeFoundFault(CallFrame frame)
+    public static RuntimeIshtarClass* MultipleTypeFoundFault(CallFrame* frame)
         => findType(MultipleTypeFoundFaultTypeName, frame);
 
-    public static RuntimeIshtarClass* PlatformIsNotSupportFault(CallFrame frame)
+    public static RuntimeIshtarClass* PlatformIsNotSupportFault(CallFrame* frame)
         => findType(PlatformIsNotSupportFaultTypeName, frame);
 
-    public static RuntimeIshtarClass* NativeFault(CallFrame frame)
+    public static RuntimeIshtarClass* NativeFault(CallFrame* frame)
         => findType(IshatFault, frame);
 
-    public static RuntimeIshtarClass* Type(CallFrame frame)
+    public static RuntimeIshtarClass* Type(CallFrame* frame)
         => findType(TypeInfoTypeName, frame);
-    public static RuntimeIshtarClass* Field(CallFrame frame)
+    public static RuntimeIshtarClass* Field(CallFrame* frame)
         => findType(FieldInfoTypeName, frame);
-    public static RuntimeIshtarClass* Function(CallFrame frame)
+    public static RuntimeIshtarClass* Function(CallFrame* frame)
         => findType(FunctionInfoTypeName, frame);
 
 
@@ -84,25 +78,25 @@ public static unsafe partial class KnowTypes
 
 
 
-    public static RuntimeIshtarClass* FromCache(QualityTypeName q, CallFrame frame)
+    public static RuntimeIshtarClass* FromCache(QualityTypeName q, CallFrame* frame)
         => findType(q.T(), frame);
 
-    public static RuntimeIshtarClass* FromCache(RuntimeQualityTypeName* q, CallFrame frame)
+    public static RuntimeIshtarClass* FromCache(RuntimeQualityTypeName* q, CallFrame* frame)
         => findType(q, frame);
 
-    private static RuntimeIshtarClass* findType(QualityTypeName q, CallFrame frame)
+    private static RuntimeIshtarClass* findType(QualityTypeName q, CallFrame* frame)
         => findType(q.T(), frame);
 
-    private static RuntimeIshtarClass* findType(RuntimeQualityTypeName* q, CallFrame frame)
+    private static RuntimeIshtarClass* findType(RuntimeQualityTypeName* q, CallFrame* frame)
     {
         if (_cache.TryGetValue((nint)q, out IntPtr type))
             return (RuntimeIshtarClass*)type;
 
-        var t = frame.method->Owner->Owner->FindType(q, true, false);
+        var t = frame->method->Owner->Owner->FindType(q, true, false);
 
         if (t->IsUnresolved)
         {
-            frame.vm.FastFail(WNE.MISSING_TYPE, $"Cannot find '{q->NameWithNS}' bulitin type", frame);
+            frame->vm.FastFail(WNE.MISSING_TYPE, $"Cannot find '{q->NameWithNS}' bulitin type", frame);
             return null;
         }
         

--- a/runtime/ishtar.vm/runtime/NativeException.cs
+++ b/runtime/ishtar.vm/runtime/NativeException.cs
@@ -1,10 +1,10 @@
 namespace ishtar
 {
-    public class NativeException
+    public unsafe class NativeException
     {
         public WNE code;
         public string msg;
-        public CallFrame frame;
+        public CallFrame* frame;
     };
 
     public enum WNE

--- a/runtime/ishtar.vm/runtime/StringStorage.cs
+++ b/runtime/ishtar.vm/runtime/StringStorage.cs
@@ -48,12 +48,12 @@ namespace ishtar
             //storage_l.Clear();
         }
 
-        public static string GetString(InternedString* p, CallFrame frame)
+        public static string GetString(InternedString* p, CallFrame* frame)
         {
             ForeignFunctionInterface.StaticValidate(p, frame);
             if (storage_l.ContainsKey((nint)p))
                 return storage_l[(nint)p];
-            frame.vm.FastFail(WNE.ACCESS_VIOLATION, "Pointer incorrect.", frame);
+            frame->vm.FastFail(WNE.ACCESS_VIOLATION, "Pointer incorrect.", frame);
             return null;
         }
 

--- a/runtime/ishtar.vm/runtime/allocators/DebugManagedAllocator.cs
+++ b/runtime/ishtar.vm/runtime/allocators/DebugManagedAllocator.cs
@@ -12,9 +12,9 @@ public sealed unsafe class DebugManagedAllocator : IIshtarAllocator
 
 
 
-    private void* Alloc(nint size, CallFrame frame)
+    private void* Alloc(nint size, CallFrame* frame)
     {
-        frame.assert(size != 0, WNE.STATE_CORRUPT, "Allocation is not allowed zero size");
+        frame->assert(size != 0, WNE.STATE_CORRUPT, "Allocation is not allowed zero size");
 
         var bytes = new byte[size];
 
@@ -30,31 +30,31 @@ public sealed unsafe class DebugManagedAllocator : IIshtarAllocator
 
     internal record struct ManagedMemHandle(nint size, GCHandle handler, nint originalAddr);
 
-    public void* AllocZeroed(ulong size, AllocationKind kind, CallFrame frame)
+    public void* AllocZeroed(ulong size, AllocationKind kind, CallFrame* frame)
     {
         TotalSize += (long)size;
         return Alloc((nint)size, frame);
     }
 
-    public void* AllocZeroed(long size, AllocationKind kind, CallFrame frame)
+    public void* AllocZeroed(long size, AllocationKind kind, CallFrame* frame)
     {
         TotalSize += size;
         return Alloc((nint)size, frame);
     }
 
-    public void* AllocZeroed(UIntPtr size, AllocationKind kind, CallFrame frame)
+    public void* AllocZeroed(UIntPtr size, AllocationKind kind, CallFrame* frame)
     {
         TotalSize += (long)size;
         return Alloc((nint)size, frame);
     }
 
-    public void* AllocZeroed(IntPtr size, AllocationKind kind, CallFrame frame)
+    public void* AllocZeroed(IntPtr size, AllocationKind kind, CallFrame* frame)
     {
         TotalSize += size;
         return Alloc(size, frame);
     }
 
-    public void* AllocZeroed(int size, AllocationKind kind, CallFrame frame)
+    public void* AllocZeroed(int size, AllocationKind kind, CallFrame* frame)
     {
         TotalSize += size;
         return Alloc(size, frame);

--- a/runtime/ishtar.vm/runtime/allocators/GCLayoutAllocator.cs
+++ b/runtime/ishtar.vm/runtime/allocators/GCLayoutAllocator.cs
@@ -7,37 +7,37 @@ public sealed unsafe class GCLayoutAllocator(GCLayout layout) : IIshtarAllocator
 {
     public long TotalSize { get; private set; }
     public nint Id { get; private set; }
-    public void* AllocZeroed(ulong size, AllocationKind kind, CallFrame frame)
+    public void* AllocZeroed(ulong size, AllocationKind kind, CallFrame* frame)
     {
         TotalSize += (long)size;
         return Alloc((nint)size, kind, frame);
     }
 
-    public void* AllocZeroed(long size, AllocationKind kind, CallFrame frame)
+    public void* AllocZeroed(long size, AllocationKind kind, CallFrame* frame)
     {
         TotalSize += size;
         return Alloc((nint)size, kind, frame);
     }
 
-    public void* AllocZeroed(UIntPtr size, AllocationKind kind, CallFrame frame)
+    public void* AllocZeroed(UIntPtr size, AllocationKind kind, CallFrame* frame)
     {
         TotalSize += (long)size;
         return Alloc((nint)size, kind, frame);
     }
 
-    public void* AllocZeroed(IntPtr size, AllocationKind kind, CallFrame frame)
+    public void* AllocZeroed(IntPtr size, AllocationKind kind, CallFrame* frame)
     {
         TotalSize += size;
         return Alloc(size, kind, frame);
     }
 
-    public void* AllocZeroed(int size, AllocationKind kind, CallFrame frame)
+    public void* AllocZeroed(int size, AllocationKind kind, CallFrame* frame)
     {
         TotalSize += size;
         return Alloc(size, kind, frame);
     }
 
-    private void* Alloc(nint size, AllocationKind kind, CallFrame frame)
+    private void* Alloc(nint size, AllocationKind kind, CallFrame* frame)
     {
         //frame.assert(size != 0, WNE.STATE_CORRUPT, "Allocation is not allowed zero size");
 

--- a/runtime/ishtar.vm/runtime/allocators/IIshtarAllocator.cs
+++ b/runtime/ishtar.vm/runtime/allocators/IIshtarAllocator.cs
@@ -11,9 +11,9 @@ public unsafe interface IIshtarAllocator : IIshtarAllocatorIdentifier, IIshtarAl
     long TotalSize { get; }
     nint Id { get; }
 
-    void* AllocZeroed(ulong size, AllocationKind kind, CallFrame frame);
-    void* AllocZeroed(long size, AllocationKind kind, CallFrame frame);
-    void* AllocZeroed(nuint size, AllocationKind kind, CallFrame frame);
-    void* AllocZeroed(nint size, AllocationKind kind, CallFrame frame);
-    void* AllocZeroed(int size, AllocationKind kind, CallFrame frame);
+    void* AllocZeroed(ulong size, AllocationKind kind, CallFrame* frame);
+    void* AllocZeroed(long size, AllocationKind kind, CallFrame* frame);
+    void* AllocZeroed(nuint size, AllocationKind kind, CallFrame* frame);
+    void* AllocZeroed(nint size, AllocationKind kind, CallFrame* frame);
+    void* AllocZeroed(int size, AllocationKind kind, CallFrame* frame);
 }

--- a/runtime/ishtar.vm/runtime/allocators/IIshtarAllocatorPool.cs
+++ b/runtime/ishtar.vm/runtime/allocators/IIshtarAllocatorPool.cs
@@ -3,8 +3,8 @@ namespace ishtar.allocators;
 
 public unsafe interface IIshtarAllocatorPool
 {
-    IIshtarAllocator Rent<T>(out T* output, AllocationKind kind, CallFrame frame) where T : unmanaged;
-    IIshtarAllocator RentArray<T>(out T* output, int size, CallFrame frame) where T : unmanaged;
+    IIshtarAllocator Rent<T>(out T* output, AllocationKind kind, CallFrame* frame) where T : unmanaged;
+    IIshtarAllocator RentArray<T>(out T* output, int size, CallFrame* frame) where T : unmanaged;
     long Return(nint p);
     long Return(void* p);
 }

--- a/runtime/ishtar.vm/runtime/allocators/IshtarAllocatorPool.cs
+++ b/runtime/ishtar.vm/runtime/allocators/IshtarAllocatorPool.cs
@@ -8,19 +8,19 @@ public sealed unsafe class IshtarAllocatorPool(GCLayout? layout) : IIshtarAlloca
     internal readonly Dictionary<nint, IIshtarAllocator> _allocators = new();
 
 
-    private IIshtarAllocator GetAllocator(CallFrame frame)
+    private IIshtarAllocator GetAllocator(CallFrame* frame)
     {
         if (layout is not null)
             return new GCLayoutAllocator(layout);
 
-        if (frame.vm.Config.UseDebugAllocator)
+        if (frame->vm.Config.UseDebugAllocator)
             return new DebugManagedAllocator();
 
         throw new NotImplementedException();
     }
 
 
-    public IIshtarAllocator Rent<T>(out T* output, AllocationKind kind, CallFrame frame) where T : unmanaged
+    public IIshtarAllocator Rent<T>(out T* output, AllocationKind kind, CallFrame* frame) where T : unmanaged
     {
         var allocator = GetAllocator(frame);
 
@@ -33,7 +33,7 @@ public sealed unsafe class IshtarAllocatorPool(GCLayout? layout) : IIshtarAlloca
         return allocator;
     }
 
-    public IIshtarAllocator RentArray<T>(out T* output, int size, CallFrame frame) where T : unmanaged
+    public IIshtarAllocator RentArray<T>(out T* output, int size, CallFrame* frame) where T : unmanaged
     {
         var allocator = GetAllocator(frame);
 

--- a/runtime/ishtar.vm/runtime/allocators/NativeMemory_WindowsAllocator.cs
+++ b/runtime/ishtar.vm/runtime/allocators/NativeMemory_WindowsAllocator.cs
@@ -9,7 +9,7 @@ public sealed unsafe class NativeMemory_WindowsAllocator : IIshtarAllocator
     public nint Id { get; private set; }
 
 
-    private void* Allocate(long size, CallFrame frame)
+    private void* Allocate(long size, CallFrame* frame)
     {
         //frame.assert(size != 0, WNE.STATE_CORRUPT, "Allocation is not allowed zero size");
         TotalSize += size;
@@ -18,19 +18,19 @@ public sealed unsafe class NativeMemory_WindowsAllocator : IIshtarAllocator
         return p;
     }
 
-    public void* AllocZeroed(ulong size, AllocationKind kind, CallFrame frame)
+    public void* AllocZeroed(ulong size, AllocationKind kind, CallFrame* frame)
         => Allocate((long)size, frame);
 
-    public void* AllocZeroed(long size, AllocationKind kind, CallFrame frame)
+    public void* AllocZeroed(long size, AllocationKind kind, CallFrame* frame)
         => Allocate(size, frame);
 
-    public void* AllocZeroed(UIntPtr size, AllocationKind kind, CallFrame frame)
+    public void* AllocZeroed(UIntPtr size, AllocationKind kind, CallFrame* frame)
         => Allocate((long)size, frame);
 
-    public void* AllocZeroed(IntPtr size, AllocationKind kind, CallFrame frame)
+    public void* AllocZeroed(IntPtr size, AllocationKind kind, CallFrame* frame)
         => Allocate(size, frame);
 
-    public void* AllocZeroed(int size, AllocationKind kind, CallFrame frame)
+    public void* AllocZeroed(int size, AllocationKind kind, CallFrame* frame)
         => Allocate(size, frame);
 
     void IIshtarAllocatorIdentifier.SetId(nint id) => Id = id;

--- a/runtime/ishtar.vm/runtime/allocators/NullAllocator.cs
+++ b/runtime/ishtar.vm/runtime/allocators/NullAllocator.cs
@@ -5,15 +5,15 @@ public sealed unsafe class NullAllocator : IIshtarAllocator
     public long TotalSize { get; }
     public IntPtr Id { get; }
 
-    public void* AllocZeroed(ulong size, AllocationKind kind, CallFrame frame) => throw new NotImplementedException();
+    public void* AllocZeroed(ulong size, AllocationKind kind, CallFrame* frame) => throw new NotImplementedException();
 
-    public void* AllocZeroed(long size, AllocationKind kind, CallFrame frame) => throw new NotImplementedException();
+    public void* AllocZeroed(long size, AllocationKind kind, CallFrame* frame) => throw new NotImplementedException();
 
-    public void* AllocZeroed(UIntPtr size, AllocationKind kind, CallFrame frame) => throw new NotImplementedException();
+    public void* AllocZeroed(UIntPtr size, AllocationKind kind, CallFrame* frame) => throw new NotImplementedException();
 
-    public void* AllocZeroed(IntPtr size, AllocationKind kind, CallFrame frame) => throw new NotImplementedException();
+    public void* AllocZeroed(IntPtr size, AllocationKind kind, CallFrame* frame) => throw new NotImplementedException();
 
-    public void* AllocZeroed(int size, AllocationKind kind, CallFrame frame) => throw new NotImplementedException();
+    public void* AllocZeroed(int size, AllocationKind kind, CallFrame* frame) => throw new NotImplementedException();
 
     public void SetId(IntPtr id) => throw new NotImplementedException();
     public void FreeAll() => throw new NotImplementedException();

--- a/runtime/ishtar.vm/runtime/allocators/WindowsHeapAllocator.cs
+++ b/runtime/ishtar.vm/runtime/allocators/WindowsHeapAllocator.cs
@@ -24,9 +24,9 @@ public sealed unsafe class WindowsHeapAllocator : IIshtarAllocator
 
     internal record struct HeapMemRef(nint heapHandle, nint memPtr, long size);
 
-    private void* AllocFromHeap(long size, CallFrame frame)
+    private void* AllocFromHeap(long size, CallFrame* frame)
     {
-        frame.assert(size != 0, WNE.STATE_CORRUPT, "Allocation is not allowed zero size");
+        frame->assert(size != 0, WNE.STATE_CORRUPT, "Allocation is not allowed zero size");
 
         TotalSize += size;
 
@@ -40,19 +40,19 @@ public sealed unsafe class WindowsHeapAllocator : IIshtarAllocator
     }
 
 
-    public void* AllocZeroed(ulong size, AllocationKind kind, CallFrame frame)
+    public void* AllocZeroed(ulong size, AllocationKind kind, CallFrame* frame)
         => AllocFromHeap((long)size, frame);
 
-    public void* AllocZeroed(long size, AllocationKind kind, CallFrame frame)
+    public void* AllocZeroed(long size, AllocationKind kind, CallFrame* frame)
         => AllocFromHeap(size, frame);
 
-    public void* AllocZeroed(UIntPtr size, AllocationKind kind, CallFrame frame)
+    public void* AllocZeroed(UIntPtr size, AllocationKind kind, CallFrame* frame)
         => AllocFromHeap((long)size, frame);
 
-    public void* AllocZeroed(IntPtr size, AllocationKind kind, CallFrame frame)
+    public void* AllocZeroed(IntPtr size, AllocationKind kind, CallFrame* frame)
         => AllocFromHeap(size, frame);
 
-    public void* AllocZeroed(int size, AllocationKind kind, CallFrame frame)
+    public void* AllocZeroed(int size, AllocationKind kind, CallFrame* frame)
         => AllocFromHeap(size, frame);
 
     void IIshtarAllocatorIdentifier.SetId(nint id) => Id = id;

--- a/runtime/ishtar.vm/runtime/gc/BoehmGCLayout.cs
+++ b/runtime/ishtar.vm/runtime/gc/BoehmGCLayout.cs
@@ -405,7 +405,7 @@ public unsafe class BoehmGCLayout : GCLayout, GCLayout_Debug
     public void find_leak() => throw new NotImplementedException();
 
 
-    public void register_finalizer_no_order(IshtarObject* obj, delegate*<nint, nint, void> proc, CallFrame frame)
+    public void register_finalizer_no_order(IshtarObject* obj, delegate*<nint, nint, void> proc, CallFrame* frame)
         => Native.GC_register_finalizer_no_order(obj, proc, null, null, null);
 
 

--- a/runtime/ishtar.vm/runtime/gc/GCLayout.cs
+++ b/runtime/ishtar.vm/runtime/gc/GCLayout.cs
@@ -21,7 +21,7 @@ public unsafe interface GCLayout
     public void finalize_all();
     public void finalize_on_demand();
 
-    public void register_finalizer_no_order(IshtarObject* obj, delegate*<nint, nint, void> proc, CallFrame frame);
+    public void register_finalizer_no_order(IshtarObject* obj, delegate*<nint, nint, void> proc, CallFrame* frame);
     public void collect();
     bool is_marked(void* obj);
 }

--- a/runtime/ishtar.vm/runtime/jit/@llmv/LLVMContext.cs
+++ b/runtime/ishtar.vm/runtime/jit/@llmv/LLVMContext.cs
@@ -6,16 +6,14 @@ using System.Runtime.InteropServices;
 using vein.extensions;
 using vein.runtime;
 
-public unsafe class LLVMContext
+public unsafe struct LLVMContext
 {
-    private readonly VirtualMachine _vm;
     private readonly LLVMOpaqueContext* _ctx;
     private LLVMModuleRef _ffiModule;
     private readonly LLVMExecutionEngineRef _executionEngine;
 
-    public LLVMContext(VirtualMachine vm)
+    public LLVMContext()
     {
-        _vm = vm;
         LLVM.LinkInMCJIT();
         LLVM.InitializeNativeAsmPrinter();
         LLVM.InitializeNativeAsmParser();
@@ -251,7 +249,7 @@ public unsafe class LLVMContext
 
     public class DeOptimizationDetected : Exception;
 
-    private LLVMTypeRef GetLLVMType(VeinTypeCode typeCode) =>
+    private static LLVMTypeRef GetLLVMType(VeinTypeCode typeCode) =>
         typeCode switch
         {
             VeinTypeCode.TYPE_BOOLEAN => LLVMTypeRef.Int1,
@@ -271,7 +269,7 @@ public unsafe class LLVMContext
             _ => throw new DeOptimizationDetected()
         };
 
-    private LLVMTypeRef GetLLVMType(RuntimeIshtarClass* clazz)
+    private static LLVMTypeRef GetLLVMType(RuntimeIshtarClass* clazz)
     {
         var type = clazz->TypeCode;
         return GetLLVMType(type);

--- a/runtime/ishtar.vm/runtime/vm/CallFrame.cs
+++ b/runtime/ishtar.vm/runtime/vm/CallFrame.cs
@@ -3,85 +3,86 @@ namespace ishtar
     using System.Runtime.CompilerServices;
     using System.Text;
     using runtime.gc;
-    using runtime;
 
     public static class CallFrameEx
     {
         public static IshtarGC GetGC(this CallFrame frame) => frame.vm.GC;
     }
 
-    public unsafe class CallFrame(VirtualMachine vm)
+    public unsafe struct CallFrame : IDisposable
     {
-        public CallFrame parent;
-        public RuntimeIshtarMethod* method;
+        public CallFrame(RuntimeIshtarMethod* m, CallFrame* parent, CallFrame* self)
+        {
+            this.Self = self;
+            this.method = m;
+            this.parent = parent;
+            this.level = 0;
+
+            if (parent is not null)
+                this.level = parent->level + 1;
+        }
+
+        public readonly CallFrame* Self ;
+        public readonly CallFrame* parent;
+        public readonly RuntimeIshtarMethod* method;
+        public readonly int level;
         public SmartPointer<stackval> returnValue;
         public stackval* args;
         public OpCodeValue last_ip;
-        public int level;
-        public VirtualMachine vm = vm;
+        public VirtualMachine vm => method->Owner->Owner->vm;
 
         public CallFrameException exception;
+
+        public CallFrame* CreateChild(RuntimeIshtarMethod* m) => Create(m, Self);
+
+        public static CallFrame* Create(RuntimeIshtarMethod* method, CallFrame* parent)
+        {
+            var frame = IshtarGC.AllocateImmortal<CallFrame>();
+
+            *frame = new CallFrame(method, parent, frame);
+
+            return frame;
+        }
+
+        private static void Free(CallFrame* frame) => IshtarGC.FreeImmortal(frame);
 
 
         public void assert(bool conditional, [CallerArgumentExpression("conditional")] string msg = default)
         {
             if (conditional)
                 return;
-            vm.FastFail(WNE.STATE_CORRUPT, $"Static assert failed: '{msg}'", this);
+            vm.FastFail(WNE.STATE_CORRUPT, $"Static assert failed: '{msg}'", Self);
         }
         public void assert(bool conditional, WNE type, [CallerArgumentExpression("conditional")] string msg = default)
         {
             if (conditional)
                 return;
-            vm.FastFail(type, $"Static assert failed: '{msg}'", this);
+            vm.FastFail(type, $"Static assert failed: '{msg}'", Self);
         }
 
 
         public void ThrowException(RuntimeIshtarClass* @class) =>
             this.exception = new CallFrameException()
             {
-                value = vm.GC.AllocObject(@class, this)
+                value = vm.GC.AllocObject(@class, Self)
             };
 
         public void ThrowException(RuntimeIshtarClass* @class, string message)
         {
             this.exception = new CallFrameException()
             {
-                value = vm.GC.AllocObject(@class, this)
+                value = vm.GC.AllocObject(@class, Self)
             };
 
             if (@class->FindField("message") is null)
                 throw new InvalidOperationException($"Class '{@class->FullName->NameWithNS}' is not contained 'message' field.");
 
             this.exception.value->vtable[@class->Field["message"]->vtable_offset]
-                = vm.GC.ToIshtarObject(message, this);
+                = vm.GC.ToIshtarObject(message, Self);
         }
 
-        public string Debug_GetFile()
-        {
-            // TODO fetch from dbg symbols
 
-            var str = new StringBuilder();
-
-            if (this.method->Owner is not null)
-                str.AppendLine($"\tat {this.method->Owner->FullName->NameWithNS}.{this.method->Name}");
-            else
-                str.AppendLine($"\tat <sys>.{this.method->Name}");
-
-            var r = this.parent;
-
-            while (r != null)
-            {
-                str.AppendLine($"\tat {r.method->Owner->FullName->NameWithNS}.{r.method->Name}");
-                r = r.parent;
-            }
-
-            return str.ToString();
-        }
-
-        public int Debug_GetLine() => 0;// TODO fetch from dbg symbols
-
-        public static void FillStackTrace(CallFrame frame)
+        public static void FillStackTrace(CallFrame* frame)
         {
             var str = new StringBuilder();
 
@@ -91,30 +92,34 @@ namespace ishtar
                 return;
             }
 
-            if (frame.method != null && !frame.method->IsDisposed() && frame.method->Owner is not null && frame.method->Owner->FullName is not null)
-                str.AppendLine($"\tat {frame.method->Owner->FullName->NameWithNS}.{frame.method->Name}");
-            else if (frame.method is not null && !frame.method->IsDisposed())
-                str.AppendLine($"\tat <sys>.{frame.method->Name}");
+            if (frame->method != null && !frame->method->IsDisposed() && frame->method->Owner is not null && frame->method->Owner->FullName is not null)
+                str.AppendLine($"\tat {frame->method->Owner->FullName->NameWithNS}.{frame->method->Name}");
+            else if (frame->method is not null && !frame->method->IsDisposed())
+                str.AppendLine($"\tat <sys>.{frame->method->Name}");
             else
                 str.AppendLine($"\tat <sys>.ukn+0");
 
 
-            var r = frame.parent;
+            var r = frame->parent;
             var index = 0;
             while (r != null)
             {
-                if (r.method is not null && !r.method->IsDisposed() && r.method->Owner is not null && r.method->Owner->FullName is not null)
-                    str.AppendLine($"\tat {r.method->Owner->FullName->NameWithNS}.{r.method->Name}");
-                else if (r.method is not null && !r.method->IsDisposed())
-                    str.AppendLine($"\tat sys.{r.method->Name}");
+                if (r->method is not null && !r->method->IsDisposed() && r->method->Owner is not null && r->method->Owner->FullName is not null)
+                    str.AppendLine($"\tat {r->method->Owner->FullName->NameWithNS}.{r->method->Name}");
+                else if (r->method is not null && !r->method->IsDisposed())
+                    str.AppendLine($"\tat sys.{r->method->Name}");
                 else
                     str.AppendLine($"\tat <sys>.ukn+{++index}");
 
-                r = r.parent;
+                r = r->parent;
             }
 
-            frame.exception ??= new CallFrameException();
-            frame.exception.stack_trace = str.ToString();
+            frame->exception = new CallFrameException
+            {
+                stack_trace = StringStorage.Intern(str.ToString())
+            };
         }
+
+        public void Dispose() => Free(Self);
     }
 }

--- a/runtime/ishtar.vm/runtime/vm/CallFrameException.cs
+++ b/runtime/ishtar.vm/runtime/vm/CallFrameException.cs
@@ -1,9 +1,21 @@
 namespace ishtar
 {
-    public unsafe class CallFrameException
+    public unsafe struct CallFrameException
     {
+        public bool IsDefault() =>
+            last_ip is null &&
+            value is null &&
+            stack_trace is null;
+
         public uint* last_ip;
         public IshtarObject* value;
-        public string stack_trace;
+        public InternedString* stack_trace;
+
+        public string GetStackTrace()
+        {
+            if (stack_trace is null)
+                return "";
+            return StringStorage.GetStringUnsafe(stack_trace);
+        }
     };
 }

--- a/runtime/ishtar.vm/runtime/vm/RuntimeIshtarField.cs
+++ b/runtime/ishtar.vm/runtime/vm/RuntimeIshtarField.cs
@@ -1,12 +1,9 @@
 namespace ishtar
 {
-    using System.Linq;
     using collections;
     using vein.runtime;
     using runtime;
     using runtime.gc;
-    using vein.reflection;
-    using Microsoft.VisualBasic.FileIO;
 
     public readonly unsafe struct WeakRef<T>(void* ptr) where T : class
     {
@@ -77,11 +74,11 @@ namespace ishtar
         }
 
 
-        public bool init_mapping(CallFrame frame)
+        public bool init_mapping(CallFrame* frame)
         {
             bool failMapping(int code, RuntimeIshtarField* field)
             {
-                frame.vm.FastFail(WNE.TYPE_LOAD,
+                frame->vm.FastFail(WNE.TYPE_LOAD,
                     $"Native aspect has incorrect mapping for '{field->FullName->Name}' field. [0x{code:X}]", frame);
                 return false;
             }

--- a/runtime/ishtar.vm/runtime/vm/RuntimeIshtarModule.cs
+++ b/runtime/ishtar.vm/runtime/vm/RuntimeIshtarModule.cs
@@ -442,7 +442,7 @@ public unsafe struct RuntimeIshtarModule : IEq<RuntimeIshtarModule>, IDisposable
 
 
 
-    public static void FillConstStorage(RuntimeConstStorage* storage, byte[] arr, CallFrame frame)
+    public static void FillConstStorage(RuntimeConstStorage* storage, byte[] arr, CallFrame* frame)
     {
         using var mem = new MemoryStream(arr);
         using var bin = new BinaryReader(mem);
@@ -683,7 +683,7 @@ public unsafe struct RuntimeIshtarModule : IEq<RuntimeIshtarModule>, IDisposable
         return mth;
     }
 
-    public RuntimeQualityTypeName* GetTypeNameByIndex(int idx, CallFrame frame)
+    public RuntimeQualityTypeName* GetTypeNameByIndex(int idx, CallFrame* frame)
     {
         if (types_table->TryGetValue(idx, out var result))
             return result;
@@ -894,7 +894,7 @@ public unsafe struct RuntimeIshtarModule : IEq<RuntimeIshtarModule>, IDisposable
 
     public RuntimeIshtarClass* Bootstrapper { get; private set; }
 
-    public CallFrame sys_frame => Vault->Value.vm.Frames.ModuleLoaderFrame;
+    public CallFrame* sys_frame => Vault->Value.vm.Frames.ModuleLoaderFrame;
     public static bool Eq(RuntimeIshtarModule* p1, RuntimeIshtarModule* p2) => p1->ID == p2->ID;
 }
 public static unsafe class QualityTypeEx
@@ -1063,7 +1063,7 @@ public unsafe struct RuntimeAspect : IEq<RuntimeAspect>, IDisposable
         Arguments->AddRange(args);
     }
 
-    public static NativeList<RuntimeAspect>* Deconstruct(RuntimeConstStorage* data, CallFrame frame, IshtarTypes* types)
+    public static NativeList<RuntimeAspect>* Deconstruct(RuntimeConstStorage* data, CallFrame* frame, IshtarTypes* types)
         => InternalDeconstruct(data);
 
     private static unsafe NativeList<RuntimeAspect>* InternalDeconstruct(RuntimeConstStorage* data)

--- a/runtime/ishtar.vm/stackval.cs
+++ b/runtime/ishtar.vm/stackval.cs
@@ -4,41 +4,39 @@ namespace ishtar
     using System.Runtime.InteropServices;
     using vein.runtime;
 
-    public struct stackval : IEq<stackval>, IDirectEq<stackval>, IEquatable<stackval>
+    public unsafe struct stackval : IEq<stackval>, IDirectEq<stackval>, IEquatable<stackval>
     {
         public stack_union data;
         public VeinTypeCode type;
         
-        public void validate(CallFrame frame, VeinTypeCode typeCode) =>
+        public void validate(CallFrame* frame, VeinTypeCode typeCode) =>
             VirtualMachine.Assert(type == VeinTypeCode.TYPE_ARRAY, WNE.TYPE_MISMATCH,
-                $"stack type mismatch, current: '{type}', expected: '{typeCode}'. opcode: '{frame.last_ip}'", frame);
+                $"stack type mismatch, current: '{type}', expected: '{typeCode}'. opcode: '{frame->last_ip}'", frame);
 
 
-        public static unsafe SmartPointer<stackval> Allocate(CallFrame frame, short size)
+        public static unsafe SmartPointer<stackval> Allocate(CallFrame* frame, short size)
             => Allocate(frame, (ushort)size);
 
-        public static unsafe SmartPointer<stackval> Allocate(CallFrame frame, ushort size)
+        public static unsafe SmartPointer<stackval> Allocate(CallFrame* frame, ushort size)
         {
             if (size == 0)
                 throw new ArgumentException($"size is not allowed zero");
 
-            static stackval* allocArray(CallFrame frame, int size)
-                => frame.vm.GC.AllocateStack(frame, size);
-            static void freeArray(CallFrame frame, stackval* stack, int size)
-                => frame.vm.GC.FreeStack(frame, stack, size);
+            static stackval* allocArray(CallFrame* frame, int size)
+                => frame->vm.GC.AllocateStack(frame, size);
+            static void freeArray(CallFrame* frame, stackval* stack, int size)
+                => frame->vm.GC.FreeStack(frame, stack, size);
 
-            static stackval* alloc(CallFrame frame, int size)
-                => frame.vm.GC.AllocValue(frame);
-            static void free(CallFrame frame, stackval* stack, int size)
-                => frame.vm.GC.FreeValue(stack);
+            static stackval* alloc(CallFrame* frame, int size)
+                => frame->vm.GC.AllocValue(frame);
+            static void free(CallFrame* frame, stackval* stack, int size)
+                => frame->vm.GC.FreeValue(stack);
 
 
             var p = new SmartPointer<stackval>(size, frame,
                 size == 1 ? &alloc : &allocArray,
                 size == 1 ? &free : &freeArray);
-#if DEBUG
-            p.CaptureAddress();
-#endif
+
             return p;
         }
 

--- a/runtime/ishtar.vm/vm.shit.cs
+++ b/runtime/ishtar.vm/vm.shit.cs
@@ -10,7 +10,7 @@ namespace ishtar
     {
         private void act<T>(ref T t1, ref T t2, A_OperationDelegate<T> actor) => actor(ref t1, ref t2);
 
-        public RuntimeQualityTypeName* readTypeName(uint index, RuntimeIshtarModule* module, CallFrame frame)
+        public RuntimeQualityTypeName* readTypeName(uint index, RuntimeIshtarModule* module, CallFrame* frame)
         {
             if (module->types_table->TryGetValue((int)index, out var result))
                 return result;
@@ -18,7 +18,7 @@ namespace ishtar
             return null;
         }
 
-        public RuntimeIshtarClass* GetClass(uint index, RuntimeIshtarModule* module, CallFrame frame)
+        public RuntimeIshtarClass* GetClass(uint index, RuntimeIshtarModule* module, CallFrame* frame)
         {
             if (!module->types_table->TryGetValue((int)index, out var name))
                 Assert(false, WNE.TYPE_LOAD, $"Cant find '{index}' in class_table.", frame);
@@ -32,7 +32,7 @@ namespace ishtar
             return type;
         }
 
-        public RuntimeIshtarMethod* GetMethod(uint index, RuntimeQualityTypeName* owner, RuntimeIshtarModule* module, CallFrame frame)
+        public RuntimeIshtarMethod* GetMethod(uint index, RuntimeQualityTypeName* owner, RuntimeIshtarModule* module, CallFrame* frame)
         {
             var clazz = module->FindType(owner, true);
             var name = module->GetConstStringByIndex((int) index);
@@ -49,7 +49,7 @@ namespace ishtar
             }
             return method;
         }
-        public RuntimeIshtarField* GetField(uint index, RuntimeIshtarClass* owner, RuntimeIshtarModule* module, CallFrame frame)
+        public RuntimeIshtarField* GetField(uint index, RuntimeIshtarClass* owner, RuntimeIshtarModule* module, CallFrame* frame)
         {
             var name = module->GetFieldNameByIndex((int) index);
             var field = owner->FindField(name->Name);
@@ -62,7 +62,7 @@ namespace ishtar
             return field;
         }
 
-        private void A_OP(stackval* sp, int a_t, uint* ip, CallFrame frame)
+        private void A_OP(stackval* sp, int a_t, uint* ip, CallFrame* frame)
         {
             if (sp[-1].type != sp[0].type)
             {

--- a/test/ishtar_test/FECallTest.cs
+++ b/test/ishtar_test/FECallTest.cs
@@ -5,7 +5,7 @@ namespace ishtar_test
     using NUnit.Framework;
 
     [TestFixture]
-    public class FECallTest : IshtarTestBase
+    public unsafe class FECallTest : IshtarTestBase
     {
         [Test]
         [Parallelizable(ParallelScope.None)]

--- a/test/ishtar_test/InstructionSizeTest.cs
+++ b/test/ishtar_test/InstructionSizeTest.cs
@@ -22,8 +22,8 @@ namespace ishtar_test
             
             var result = scope.Compile().Execute().Validate();
 
-            Assert.AreEqual(VeinTypeCode.TYPE_I8, (result.returnValue[0]).type);
-            Assert.AreEqual(long.MaxValue, (result.returnValue[0]).data.l);
+            Assert.AreEqual(VeinTypeCode.TYPE_I8, (result->returnValue[0]).type);
+            Assert.AreEqual(long.MaxValue, (result->returnValue[0]).data.l);
         }
     }
 }

--- a/test/ishtar_test/InstructionTest.cs
+++ b/test/ishtar_test/InstructionTest.cs
@@ -37,8 +37,8 @@ namespace ishtar_test
                 .Execute()
                 .Validate();
 
-            Assert.AreEqual(code, (result.returnValue[0]).type);
-            Assert.AreEqual(10, (result.returnValue[0]).data.l);
+            Assert.AreEqual(code, (result->returnValue[0]).type);
+            Assert.AreEqual(10, (result->returnValue[0]).data.l);
         }
 
         [Test]
@@ -64,8 +64,8 @@ namespace ishtar_test
                 .Execute()
                 .Validate();
 
-            Assert.AreEqual(code, (result.returnValue[0]).type);
-            Assert.AreEqual(5, (result.returnValue[0]).data.l);
+            Assert.AreEqual(code, (result->returnValue[0]).type);
+            Assert.AreEqual(5, (result->returnValue[0]).data.l);
         }
 
         [Test]
@@ -89,8 +89,8 @@ namespace ishtar_test
                 .Execute()
                 .Validate();
 
-            Assert.AreEqual(code, (result.returnValue[0]).type);
-            Assert.AreEqual(5 * 5, (result.returnValue[0]).data.l);
+            Assert.AreEqual(code, (result->returnValue[0]).type);
+            Assert.AreEqual(5 * 5, (result->returnValue[0]).data.l);
         }
 
         [Test]
@@ -114,8 +114,8 @@ namespace ishtar_test
                 .Execute()
                 .Validate();
 
-            Assert.AreEqual(code, (result.returnValue[0]).type);
-            Assert.AreEqual(5 / 5, (result.returnValue[0]).data.l);
+            Assert.AreEqual(code, (result->returnValue[0]).type);
+            Assert.AreEqual(5 / 5, (result->returnValue[0]).data.l);
         }
 
         [Test]
@@ -139,8 +139,8 @@ namespace ishtar_test
                 .Execute()
                 .Validate();
 
-            Assert.AreEqual(code, (result.returnValue[0]).type);
-            Assert.AreEqual(5 % 5, (result.returnValue[0]).data.l);
+            Assert.AreEqual(code, (result->returnValue[0]).type);
+            Assert.AreEqual(5 % 5, (result->returnValue[0]).data.l);
         }
 
         [Test]
@@ -165,8 +165,8 @@ namespace ishtar_test
                 .Execute()
                 .Validate();
 
-            Assert.AreEqual(VeinTypeCode.TYPE_R4, (result.returnValue[0]).type);
-            Assert.AreEqual(expected, (result.returnValue[0]).data.f_r4);
+            Assert.AreEqual(VeinTypeCode.TYPE_R4, (result->returnValue[0]).type);
+            Assert.AreEqual(expected, (result->returnValue[0]).data.f_r4);
         }
 
         [Test, Ignore("Emit 'ldc.i2.s' resulted in an invalid buffer size value. amount: 4, excepted: 2")]
@@ -191,8 +191,8 @@ namespace ishtar_test
                 .Execute()
                 .Validate();
 
-            Assert.AreEqual(VeinTypeCode.TYPE_R4, (result.returnValue[0]).type);
-            Assert.AreEqual(expected, (result.returnValue[0]).data.f_r4);
+            Assert.AreEqual(VeinTypeCode.TYPE_R4, (result->returnValue[0]).type);
+            Assert.AreEqual(expected, (result->returnValue[0]).data.f_r4);
         }
 
         [Test]
@@ -217,8 +217,8 @@ namespace ishtar_test
                 .Execute()
                 .Validate();
 
-            Assert.AreEqual(VeinTypeCode.TYPE_R16, (result.returnValue[0]).type);
-            Assert.AreEqual((decimal)expected, (result.returnValue[0]).data.d);
+            Assert.AreEqual(VeinTypeCode.TYPE_R16, (result->returnValue[0]).type);
+            Assert.AreEqual((decimal)expected, (result->returnValue[0]).data.d);
         }
 
         [Test]
@@ -244,8 +244,8 @@ namespace ishtar_test
                 .Execute()
                 .Validate();
 
-            Assert.AreEqual(VeinTypeCode.TYPE_R8, (result.returnValue[0]).type);
-            Assert.AreEqual((double)expected, (result.returnValue[0]).data.f);
+            Assert.AreEqual(VeinTypeCode.TYPE_R8, (result->returnValue[0]).type);
+            Assert.AreEqual((double)expected, (result->returnValue[0]).data.f);
         }
 
         [Test]
@@ -267,8 +267,8 @@ namespace ishtar_test
                 .Execute()
                 .Validate();
 
-            Assert.AreEqual(VeinTypeCode.TYPE_R8, (result.returnValue[0]).type);
-            Assert.AreEqual(expected, (result.returnValue[0]).data.f);
+            Assert.AreEqual(VeinTypeCode.TYPE_R8, (result->returnValue[0]).type);
+            Assert.AreEqual(expected, (result->returnValue[0]).data.f);
         }
 
 
@@ -324,8 +324,8 @@ namespace ishtar_test
                 .Execute()
                 .Validate();
 
-            Assert.AreEqual(code, (result.returnValue[0]).type);
-            Assert.AreEqual(5 * 5, (result.returnValue[0]).data.l);
+            Assert.AreEqual(code, (result->returnValue[0]).type);
+            Assert.AreEqual(5 * 5, (result->returnValue[0]).data.l);
         }
 
         [Test]
@@ -346,9 +346,9 @@ namespace ishtar_test
                 .Execute()
                 .Validate();
 
-            Assert.AreEqual(VeinTypeCode.TYPE_STRING, (result.returnValue[0]).type);
+            Assert.AreEqual(VeinTypeCode.TYPE_STRING, (result->returnValue[0]).type);
 
-            var obj = (IshtarObject*) result.returnValue[0].data.p;
+            var obj = (IshtarObject*) result->returnValue[0].data.p;
             Assert.AreEqual(targetStr, IshtarMarshal.ToDotnetString(obj, null));
         }
 
@@ -376,7 +376,7 @@ namespace ishtar_test
                 .Validate();
 
 
-            Assert.AreEqual(142, result.returnValue[0].data.l);
+            Assert.AreEqual(142, result->returnValue[0].data.l);
         }
     }
 }

--- a/test/ishtar_test/IshtarTestBase.cs
+++ b/test/ishtar_test/IshtarTestBase.cs
@@ -98,7 +98,7 @@ namespace ishtar_test
         private readonly VeinModuleBuilder _veinModule;
         private readonly string _testCase;
         private readonly string _uid;
-        public CallFrame entryPointFrame;
+        public CallFrame* entryPointFrame;
         private RuntimeIshtarMethod* entryPointMethod;
 
         private readonly NativeList<RuntimeIshtarModule>* _deps;
@@ -132,12 +132,9 @@ namespace ishtar_test
             entryPointMethod = runtimeModule->GetSpecialEntryPoint($"master_{_testCase}_{_uid}()");
 
             var args_ = stackalloc stackval[1];
-            var frame = new CallFrame(VM)
-            {
-                args = args_,
-                method = entryPointMethod,
-                level = 0
-            };
+
+            var frame = CallFrame.Create(entryPointMethod, null);
+            frame->args = args_;
             entryPointFrame = frame;
         }
 
@@ -148,14 +145,14 @@ namespace ishtar_test
             return this;
         }
 
-        public CallFrame Validate()
+        public CallFrame* Validate()
         {
-            if (entryPointFrame.exception is not null)
-            {
-                var ex = entryPointFrame.exception.value;
-                var clazz = ex->clazz;
-                Assert.Fail($"Fault has throw. [{clazz->Name}]");
-            }
+            if (entryPointFrame->exception.value == null)
+                return entryPointFrame;
+
+            var ex = entryPointFrame->exception.value;
+            var clazz = ex->clazz;
+            Assert.Fail($"Fault has throw. [{clazz->Name}]");
 
             return entryPointFrame;
         }

--- a/test/ishtar_test/MethodExecuteTest.cs
+++ b/test/ishtar_test/MethodExecuteTest.cs
@@ -30,7 +30,7 @@ public unsafe class MethodExecuteTest : IshtarTestBase
 
         var result = scope.Compile().Execute().Validate();
 
-        Assert.AreEqual(result.returnValue[0].data.i, 225 * 2);
+        Assert.AreEqual(result->returnValue[0].data.i, 225 * 2);
     }
 
     [Test]
@@ -61,7 +61,7 @@ public unsafe class MethodExecuteTest : IshtarTestBase
 
         var result = scope.Compile().Execute().Validate();
 
-        Assert.AreEqual(result.returnValue[0].data.i, 2 * 2 * 2);
+        Assert.AreEqual(result->returnValue[0].data.i, 2 * 2 * 2);
     }
 
     [Test]
@@ -88,7 +88,7 @@ public unsafe class MethodExecuteTest : IshtarTestBase
 
         var result = scope.Compile().Execute().Validate();
 
-        Assert.AreEqual(result.last_ip, OpCodeValue.RET);
+        Assert.AreEqual(result->last_ip, OpCodeValue.RET);
     }
 
 }

--- a/test/ishtar_test/TestWatchDog.cs
+++ b/test/ishtar_test/TestWatchDog.cs
@@ -13,12 +13,12 @@ namespace ishtar_test
         { }
     }
     [ExcludeFromCodeCoverage]
-    public class TestWatchDog : IWatchDog
+    public unsafe class TestWatchDog : IWatchDog
     {
         private static readonly object guarder = new();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        void IWatchDog.FastFail(WNE type, string msg, CallFrame frame)
+        void IWatchDog.FastFail(WNE type, string msg, CallFrame* frame)
         {
             lock (guarder)
             {

--- a/test/ishtar_test/ishtar_test.csproj
+++ b/test/ishtar_test/ishtar_test.csproj
@@ -16,6 +16,8 @@
     <DebugSymbols>True</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifier>
+    <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\runtime\ishtar.vm\ishtar.vm.csproj" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated various method signatures to use pointers for `CallFrame` parameters across multiple files.
  - Changed `IshtarTrace` from a class to a struct and removed its constructor.
  - Refactored `CallFrame` creation and exception handling in `Program.cs`.

- **Chores**
  - Added a project reference to `ishtar.vm.libuv.csproj`.

These changes aim to enhance performance and memory management within the Ishtar VM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->